### PR TITLE
Fixed ZX81 basic loader conversion of variables that contain multiple digits

### DIFF
--- a/Source/zx81/zx81BasicLoader.cpp
+++ b/Source/zx81/zx81BasicLoader.cpp
@@ -241,6 +241,7 @@ void zx81BasicLoader::OutputLine(int lineNumber, int& addressOffset)
 
         bool withinQuotes = false;
         bool withinRem = false;
+        bool startsWithAlpha = false;
 
         while (mLineBuffer[i] != '\0')
         {
@@ -257,7 +258,16 @@ void zx81BasicLoader::OutputLine(int lineNumber, int& addressOffset)
                                 withinRem = true;
                         }
 
-                        if (!withinQuotes && !withinRem && StartOfNumber(i))
+                        if (startsWithAlpha && !isalpha(mLineBuffer[i]) && !isdigit(mLineBuffer[i]))
+                        {
+                                startsWithAlpha = false;
+                        }
+                        else if (!withinQuotes && !withinRem && isalpha(mLineBuffer[i]))
+                        {
+                                startsWithAlpha = true;
+                        }
+
+                        if (!withinQuotes && !withinRem && !startsWithAlpha && StartOfNumber(i))
                         {
                                 const bool binaryFormatFlag = false;
                                 OutputEmbeddedNumber(i, addressOffset, binaryFormatFlag);

--- a/Source/zx81/zx81BasicLoader.cpp
+++ b/Source/zx81/zx81BasicLoader.cpp
@@ -258,7 +258,7 @@ void zx81BasicLoader::OutputLine(int lineNumber, int& addressOffset)
                                 withinRem = true;
                         }
 
-                        if (startsWithAlpha && !isalpha(mLineBuffer[i]) && !isdigit(mLineBuffer[i]))
+                        if (startsWithAlpha && !isalpha(mLineBuffer[i]) && !isdigit(mLineBuffer[i]) && !isspace(mLineBuffer[i]))
                         {
                                 startsWithAlpha = false;
                         }


### PR DESCRIPTION
Fixed importing basic listings on the ZX81, which does not properly handle variable names that contain multiple numeric digits.