### PR TITLE
Fixed label and streamlined warnings from 3rd party code

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -2838,7 +2838,7 @@ void THW::SaveSettings(TIniFile *ini)
         ini->WriteInteger("HWARE","QLCPU",QLCPU->ItemIndex);
         ini->WriteInteger("HWARE","QLMEM",QLMem->ItemIndex);
         ini->WriteInteger("HWARE","Colour",ColourBox->ItemIndex);
-        ini->WriteInteger("HWARE","speech",SpeechBox->ItemIndex);
+        ini->WriteInteger("HWARE","Speech",SpeechBox->ItemIndex);
         ini->WriteInteger("HWARE","RomCartridge",RomCartridgeBox->ItemIndex);
         ini->WriteString("HWARE","RomCartridgeFile",RomCartridgeFileBox->Text);
         ini->WriteInteger("HWARE","ZXC1Configuration",ZXC1ConfigurationBox->ItemIndex);

--- a/Source/SP0256/sp0256.c
+++ b/Source/SP0256/sp0256.c
@@ -33,6 +33,10 @@
  * ============================================================================
  */
 
+#if __CODEGEARC__ < 0x0620
+#pragma warn -8004
+#endif
+
 //#define SINGLE_STEP
 
 #define jzp_printf printf
@@ -237,6 +241,8 @@ static int lpc12_update(lpc12_t *f, int num_samp, int16_t *out, uint32_t *optr)
 
             f->amp   = amp_decode(f->r[0]);
             f->per   = f->r[1];
+
+            do_int   = 0;
         }
 
         /* ---------------------------------------------------------------- */
@@ -692,7 +698,7 @@ static INLINE uint32_t bitrev(uint32_t val)
 /* ======================================================================== */
 static uint32_t sp0256_getb(ivoice_t *ivoice, int len)
 {
-    uint32_t data;
+    uint32_t data = 0;
     uint32_t d0, d1;
 
     /* -------------------------------------------------------------------- */
@@ -762,8 +768,8 @@ static void sp0256_micro(ivoice_t *iv)
     uint8_t  immed4;
     uint8_t  opcode;
     uint16_t cr;
-    int      ctrl_xfer;
-    int      repeat;
+    int      ctrl_xfer = 0;
+    int      repeat    = 0;
     int      i, idx0, idx1;
 
     /* -------------------------------------------------------------------- */
@@ -1021,6 +1027,7 @@ static void sp0256_micro(ivoice_t *iv)
             clrL  = cr & CR_CLRL;
             delta = cr & CR_DELTA;
             field = cr & CR_FIELD;
+            value = 0;
 
             jzdprintf(("$%.4X.%.1X: len=%2d shf=%2d prm=%2d d=%d f=%d ",
                      iv->pc >> 3, iv->pc & 7, len, shf, prm, !!delta, !!field));


### PR DESCRIPTION
- Fixed configuration file "speech" label case
- Minimize changes to 3rd party code by inserting a conditional warning suppression statement at the top of the offending file. Note that this warning does not happen on the newer compilers. I recommend not modifying 3rd party code unless necessary. This makes maintenance easier.