### PR TITLE
Updated warning suppression to work across all used compiler versions

### DIFF
--- a/Source/1772/wd1770.c
+++ b/Source/1772/wd1770.c
@@ -25,9 +25,7 @@
 
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include <errno.h>
 #include <stdlib.h>

--- a/Source/68k/68000.c
+++ b/Source/68k/68000.c
@@ -29,9 +29,8 @@
  */
 //static char     sccsid[] = "$Id: 68000.c,v 1.20 2002/10/30 16:23:04 jhoenig Exp $";
 
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
-#endif
 
 #include "68kconfig.h"
 

--- a/Source/68k/68000.h
+++ b/Source/68k/68000.h
@@ -183,7 +183,7 @@ extern int      QueryIRQ(int level); /* get interrupt vector number */
 //extern unsigned char     (*mem_get_b[MEMTABLESIZE]) (unsigned long address);
 //extern unsigned short    (*mem_get_w[MEMTABLESIZE]) (unsigned long address);
 //extern unsigned long     (*mem_get_l[MEMTABLESIZE]) (unsigned long address);
-extern unsigned char memory[];
+//extern unsigned char memory[];
 //#endif
 /* Fetch byte from address */
 extern char GetMemB(unsigned long address);

--- a/Source/68k/op68kadd.c
+++ b/Source/68k/op68kadd.c
@@ -14,10 +14,9 @@
  *  30.10.2002  JH  Replaced "% 8" with "& 7". Helps lesser compilers to generate faster code.
  */
 
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 
 #ifndef PROTOH

--- a/Source/68k/op68karith.c
+++ b/Source/68k/op68karith.c
@@ -19,11 +19,9 @@
 
 #pragma option push
 #pragma warn -8004
-
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 

--- a/Source/68k/op68klogop.c
+++ b/Source/68k/op68klogop.c
@@ -14,10 +14,8 @@
  *  30.10.2002  JH  Replaced "% 8" with "& 7". Helps lesser compilers to generate faster code.
  */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 //static char     sccsid[] = "$Id: op68klogop.c,v 1.5 2002/10/30 16:23:06 jhoenig Exp $";

--- a/Source/68k/op68kmisc.c
+++ b/Source/68k/op68kmisc.c
@@ -27,11 +27,9 @@
 
 #pragma option push
 #pragma warn -8004
-
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 

--- a/Source/68k/op68kmove.c
+++ b/Source/68k/op68kmove.c
@@ -12,10 +12,9 @@
  *  30.10.2002  JH  Replaced "% 8" with "& 7". Helps lesser compilers to generate faster code.
  */
 
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 //static char     sccsid[] = "$Id: op68kmove.c,v 1.2 2002/10/30 16:23:06 jhoenig Exp $";

--- a/Source/68k/op68kshift.c
+++ b/Source/68k/op68kshift.c
@@ -21,10 +21,9 @@
  *  30.10.2002  JH  Replaced "% 8" with "& 7". Helps lesser compilers to generate faster code.
  */
 
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 //static char     sccsid[] = "$Id: op68kshift.c,v 1.11 2002/10/30 16:23:06 jhoenig Exp $";

--- a/Source/68k/op68ksub.c
+++ b/Source/68k/op68ksub.c
@@ -14,10 +14,9 @@
  *  30.10.2002  JH  Replaced "% 8" with "& 7". Helps lesser compilers to generate faster code.
  */
 
-#if __CODEGEARC__ < 0x0620
+#pragma warn -8008
 #pragma warn -8066
 #pragma warn -8071
-#endif
 
 #ifndef PROTOH
 

--- a/Source/BasicLister/IBasicLister.cpp
+++ b/Source/BasicLister/IBasicLister.cpp
@@ -16,8 +16,11 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "IBasicLister.h"
 #include <vcl4.h>
+#pragma hdrstop
+
+#include "IBasicLister.h"
+#include "zx81config.h"
 #include <sstream>
 #include <iomanip>
 #include <string>

--- a/Source/DebugWin/SearchSequence_.cpp
+++ b/Source/DebugWin/SearchSequence_.cpp
@@ -1,8 +1,7 @@
 //---------------------------------------------------------------------------
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8066
-#endif
+#pragma warn -8008
 
 #include <vcl4.h>
 #pragma hdrstop

--- a/Source/EightyOne.bpr
+++ b/Source/EightyOne.bpr
@@ -81,8 +81,7 @@
     <INCLUDEPATH value="ql\;ql;SP0256;C:\;Display;peripherals\zxprinter;BasicLoader;BasicLister;ProgramLister;Chroma;Spectra;RomCartridge;$(BCB)\include;$(BCB)\include\vcl;zxpand;cr81;1541;IECBus;rzx;Debug68k;zlib\minizip;zlib;1772;68k;ide;libdsk;lib765;Spectrum;Ace;tzx;peripherals;Timer;sound;DebugWin;wavtape;zxprinter;TapeMan;zx81;z80;..\Components\Animation-Timer\lib;&quot;..\Components\Office Button 97\OffBtn97&quot;;&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot;;&quot;..\Components\ComPort Library&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\CBuilder&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot;"/>
     <LIBPATH value="ql\;ql;SP0256;C:\;Display;peripherals\zxprinter;BasicLoader;BasicLister;ProgramLister;Chroma;Spectra;RomCartridge;$(BCB)\lib;$(BCB)\lib\obj;$(BCB)\Projects\lib;zxpand;cr81;1541;IECBus;rzx;Debug68k;zlib\minizip;zlib;1772;68k;ide;libdsk;lib765;Spectrum;Ace;tzx;peripherals;Timer;sound;DebugWin;wavtape;zxprinter;TapeMan;zx81;z80;..\Components\DirectDraw;&quot;..\Components\Office Button 97\OffBtn97&quot;;&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot;;&quot;..\Components\ComPort Library&quot;;..\Components\DirectSound"/>
     <WARNINGS value="-w8092 -w8090 -w8089 -w8087 -wprc -wuse -wucp -wstv -wstu -wsig -wpin 
-      -w-par -wnod -wnak -w-8027 -w-8026 -wdef -wcln -w-ccc -wbbf -wasm -wamp 
-      -wamb"/>
+      -w-par -wnod -wnak -w-8027 -w-8026 -wdef -wcln -wbbf -wasm -wamp -wamb"/>
   </MACROS>
   <OPTIONS>
     <IDLCFLAGS value="-Iql\. -Iql -ISP0256 -IC:\. -IDisplay -Iperipherals\zxprinter 

--- a/Source/SP0256/audio.cpp
+++ b/Source/SP0256/audio.cpp
@@ -23,9 +23,7 @@
     along with SP0256_CTS256A-AL2.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8080
-#endif
 
 #include "audio.h"
 

--- a/Source/SP0256/sp0256.c
+++ b/Source/SP0256/sp0256.c
@@ -33,11 +33,9 @@
  * ============================================================================
  */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8004
 #pragma warn -8071
 #pragma warn -8080
-#endif
 
 //#define SINGLE_STEP
 

--- a/Source/SP0256/types.h
+++ b/Source/SP0256/types.h
@@ -39,6 +39,10 @@ typedef unsigned long ulong;
 
 #include <cstdint>
 
+#elif __CODEGEARC__ >= 0x0620
+
+#include <cstdint>
+
 #else
 
 typedef uchar uint8_t;

--- a/Source/floppy.c
+++ b/Source/floppy.c
@@ -1,6 +1,4 @@
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8080
-#endif
 
 #include <stdlib.h>
 #include <mem.h>

--- a/Source/ide/ide.cpp
+++ b/Source/ide/ide.cpp
@@ -1,3 +1,5 @@
+#pragma warn -8008
+
 #include <stdio.h>
 #include <string.h>
 #include "ide.h"

--- a/Source/lib765/765drive.c
+++ b/Source/lib765/765drive.c
@@ -21,9 +21,7 @@
 
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include "765i.h"
 

--- a/Source/lib765/765dsk.c
+++ b/Source/lib765/765dsk.c
@@ -21,9 +21,7 @@
 
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include "765i.h"
 

--- a/Source/lib765/765fdc.c
+++ b/Source/lib765/765fdc.c
@@ -18,9 +18,7 @@
 
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include "765i.h"
 

--- a/Source/lib765/765ldsk.c
+++ b/Source/lib765/765ldsk.c
@@ -21,9 +21,7 @@
 
 */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include "config.h"
 #ifdef HAVE_LIBDSK_H

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -44,9 +44,7 @@
  * between <=2% CPU use and *30*% CPU use pretty much at random...)
  */
 
-#if __CODEGEARC__ < 0x0620
 #pragma warn -8071
-#endif
 
 #include "sound\sound.h"
 #include "sound\soundop.h"


### PR DESCRIPTION
- Compatibility with a newer compiler was improved by switching to the "classic" version of Bcc32. Therefore, the warnings shown align more closely with the older versions of the compiler, requiring conditional compiler checks to be removed.
- Rearranged IBasicLister includes to align with other source files, fixing errors on the newer compiler.
- Commented unused memory array declaration.
- Fixed a type redefinition problem that was only seen on the newer compiler.