### PR TITLE
Added wait behavior to Sweet Talker

### DIFF
--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -974,8 +974,11 @@ void spec48_writeport(int Address, int Data, int *tstates)
         switch(Address&255)
         {
         case 0x07:
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1) sp0256_AL2->Write((BYTE)Data);
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2) sp0256_AL2->Write((BYTE)Data);
+                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1 || machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
+                {
+                        while (sp0256_AL2->Busy()) {}
+                        sp0256_AL2->Write((BYTE)Data);
+                }
                 break;
 
         case 0x1b:
@@ -985,7 +988,11 @@ void spec48_writeport(int Address, int Data, int *tstates)
         case 0x1f:
                 if (spectrum.floppytype==FLOPPYDISCIPLE) floppy_set_motor((BYTE)Data);
                 if (spectrum.floppytype==FLOPPYBETA && PlusDPaged) floppy_write_cmdreg((BYTE)Data);
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2) sp0256_AL2->Write((BYTE)Data);
+                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
+                {
+                        while (sp0256_AL2->Busy()) {}
+                        sp0256_AL2->Write((BYTE)Data);
+                }
                 break;
 
         case 0x3f:

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -976,8 +976,8 @@ void spec48_writeport(int Address, int Data, int *tstates)
         case 0x07:
                 if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1 || machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
                 {
-                        while (sp0256_AL2->Busy()) {}
                         sp0256_AL2->Write((BYTE)Data);
+                        while (sp0256_AL2->Busy()) {}
                 }
                 break;
 
@@ -990,8 +990,8 @@ void spec48_writeport(int Address, int Data, int *tstates)
                 if (spectrum.floppytype==FLOPPYBETA && PlusDPaged) floppy_write_cmdreg((BYTE)Data);
                 if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
                 {
-                        while (sp0256_AL2->Busy()) {}
                         sp0256_AL2->Write((BYTE)Data);
+                        while (sp0256_AL2->Busy()) {}
                 }
                 break;
 

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -1158,8 +1158,8 @@ void zx81_writeport(int Address, int Data, int *tstates)
                 if (zxpand) zxpand->IO_Write(Address>>8, Data);
                 if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1 || machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
                 {
-                        while (sp0256_AL2->Busy()) {}
                         sp0256_AL2->Write((BYTE)Data);
+                        while (sp0256_AL2->Busy()) {}
                 }
                 break;
 
@@ -1172,8 +1172,8 @@ void zx81_writeport(int Address, int Data, int *tstates)
                 if (machine.aytype==AY_TYPE_ZONX_REV2) Sound.AYWrite(SelectAYReg, Data,frametstates);
                 if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
                 {
-                        while (sp0256_AL2->Busy()) {}
                         sp0256_AL2->Write((BYTE)Data);
+                        while (sp0256_AL2->Busy()) {}
                 }
                 break;
 

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -1156,8 +1156,11 @@ void zx81_writeport(int Address, int Data, int *tstates)
 
         case 0x07:
                 if (zxpand) zxpand->IO_Write(Address>>8, Data);
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1) sp0256_AL2->Write((BYTE)Data);
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2) sp0256_AL2->Write((BYTE)Data);
+                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV1 || machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
+                {
+                        while (sp0256_AL2->Busy()) {}
+                        sp0256_AL2->Write((BYTE)Data);
+                }
                 break;
 
         case 0x0f:
@@ -1167,7 +1170,11 @@ void zx81_writeport(int Address, int Data, int *tstates)
 
         case 0x1f:
                 if (machine.aytype==AY_TYPE_ZONX_REV2) Sound.AYWrite(SelectAYReg, Data,frametstates);
-                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2) sp0256_AL2->Write((BYTE)Data);
+                if (machine.speech == SPEECH_TYPE_SWEETTALKER_REV2)
+                {
+                        while (sp0256_AL2->Busy()) {}
+                        sp0256_AL2->Write((BYTE)Data);
+                }
                 break;
 
         case 0x73:


### PR DESCRIPTION
The Sweet Talker implementation had no way to wait for the processing of an allophone to complete before moving to the next instruction. Added assertion of CPU WAIT behavior after each write to the device.