### PR TITLE
Updated SP0256 constant declarations and adjusted output data type

### DIFF
--- a/Source/SP0256/sp0256.c
+++ b/Source/SP0256/sp0256.c
@@ -51,7 +51,7 @@
 
 static int s_debugSample = 0;
 
-#if 1
+#if 0
 #define dsprintf(x) if( s_debugSample ) { jzp_printf x ; jzp_flush(); }
 #else
 #undef DEBUG_SAMPLE
@@ -65,11 +65,11 @@ static int s_debugSample = 0;
 
 static int s_debug = 0;
 
-#if 1
+#if 0
 #define jzdprintf(x) if( s_debug ) { jzp_printf x ; jzp_flush(); }
 #else
 #undef DEBUG
-#define DEBUG
+//#define DEBUG
 #ifdef DEBUG
 #define jzdprintf(x) jzp_printf x ; jzp_flush()
 #else

--- a/Source/SP0256/sp0256.c
+++ b/Source/SP0256/sp0256.c
@@ -1334,7 +1334,7 @@ int sp0256_isNextSample()
 }
 */
 
-int sp0256_getNextSample()
+int16_t sp0256_getNextSample()
 {
     ivoice_t *ivoice = &intellivoice;
 	uint32_t optr = 0;

--- a/Source/SP0256/sp0256.h
+++ b/Source/SP0256/sp0256.h
@@ -100,7 +100,7 @@ void sp0256_reset();
 /*
 int sp0256_isNextSample();
 */
-int sp0256_getNextSample();
+int16_t sp0256_getNextSample();
 int sp0256_exec();
 void sp0256_setLabels( int nLabels, const char *labels[] );
 void sp0256_setDebug( int debug );

--- a/Source/SP0256/sp0256drv.cpp
+++ b/Source/SP0256/sp0256drv.cpp
@@ -3,13 +3,14 @@
 #include "sp0256_al2.h"	// SP0256-AL2 "Narrator"
 #include "sp0256_012.h"	// SP0256-012 "Intellivoice"
 
+static const int c_xtal = 3120000;
+static const double c_freq = c_xtal/2/156;
+
 SP0256 sp0256_AL2(_AL2);
 //SP0256 sp0256_ivoice(_012);
 
 SP0256::SP0256(model_t model) :
-        m_xtal(3120000),
-        m_freq(m_xtal/2/156),
-        m_scaler(22000/m_freq),
+        m_scaler(1.0),
         m_sample_count(0.0),
         m_lastsample(0)
 {
@@ -38,19 +39,18 @@ bool SP0256::Busy(void)
 
 void SP0256::SetSamplingFreq(int freq)
 {
-        m_scaler = freq/m_freq;
+        if (freq > 0)
+                m_scaler = freq/c_freq;
 }
 
-char SP0256::GetNextSample(void)
+int16_t SP0256::GetNextSample(void)
 {
         m_sample_count += 1.0;
 
         while (m_sample_count >= m_scaler)
         {
                 m_sample_count -= m_scaler;
-                int sample = sp0256_getNextSample();
-       	        sample >>= 8;
-                m_lastsample = (char)(sample & 0xFF);
+                m_lastsample = sp0256_getNextSample();
         }
 
         return m_lastsample;

--- a/Source/SP0256/sp0256drv.h
+++ b/Source/SP0256/sp0256drv.h
@@ -16,16 +16,14 @@ public:
         SP0256(model_t model);
         void Write(unsigned char Data);
         bool Busy(void);
-        char GetNextSample(void);
+        int16_t GetNextSample(void);
         void Reset();
         void SetSamplingFreq(int freq);
 
 private:
-        const int m_xtal;
-        const double m_freq;
         double m_scaler;
         double m_sample_count;
-        char m_lastsample;
+        int16_t m_lastsample;
 };
 
 

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -506,7 +506,7 @@ void CSound::Frame(void)
         ptr=Buffer;
         for(f=0;f<FrameSize;f++)
         {
-                char temp = (sp0256_AL2.GetNextSample()*VolumeLevel[4])/31;
+                char temp = ((sp0256_AL2.GetNextSample()/256)*VolumeLevel[4])/31;
                 *(ptr++)+=temp;
                 if(m_Channels == 2)
                         *(ptr++)+=temp;


### PR DESCRIPTION
- Move SP0256 constants to local static variables.
- Range check the input sampling frequency to ensure its greater than zero.
- Flow the actual output data type up through the driver interface.
- Disabled debug print statements in SP0256 emulator