### PR TITLE
Fix initial volume bug and changed sound visualization to single channel

### DIFF
--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -34,7 +34,7 @@
 TSoundOutput *SoundOutput;
 //---------------------------------------------------------------------------
 
-void TSoundOutput::UpdateImage(unsigned char *data, int len)
+void TSoundOutput::UpdateImage(unsigned char *data, int channels)
 {
         long x;
         static int skip=0;
@@ -55,7 +55,7 @@ void TSoundOutput::UpdateImage(unsigned char *data, int len)
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
-                Img->LineTo(x, data[2*x]/2);
+                Img->LineTo(x, data[channels*x]/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -55,7 +55,7 @@ void TSoundOutput::UpdateImage(unsigned char *data, int len)
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
-                Img->LineTo(x, data[x]/2);
+                Img->LineTo(x, data[2*x]/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -41,7 +41,7 @@ private:	// User declarations
         TCanvas *Img;
 public:		// User declarations
         __fastcall TSoundOutput(TComponent* Owner);
-        void UpdateImage(unsigned char *data, int len);
+        void UpdateImage(unsigned char *data, int channels);
         void LoadSettings(TIniFile *ini);
 };
 //---------------------------------------------------------------------------

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -146,8 +146,6 @@ void CSound::AYInit(void)
         int f,clock;
         double v;
 
-        for(f=0;f<4;f++) VolumeLevel[f]=AMPL_AY_TONE;
-
         // logarithmic volume levels, 3dB per step
         v=AMPL_AY_TONE;
         for(f=15;f>0;f--)

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -511,7 +511,7 @@ void CSound::Frame(void)
         }
 
         DXSound.Frame(Buffer, FrameSize*m_Channels);
-        SoundOutput->UpdateImage(Buffer,FrameSize*m_Channels);
+        SoundOutput->UpdateImage(Buffer,m_Channels);
 
         OldPos=-1;
         FillPos=0;


### PR DESCRIPTION
- Sound volume controls were incorrect after program startup and didn't match the volume sliders.
- The sound waveform showed two audio channels (stereo), which are usually identical. Changed to show only one of the channels, resulting in a longer period of visualization. 