### PR TITLE
Update sound output to 16-bit data

### DIFF
--- a/Source/EightyOne.bpr
+++ b/Source/EightyOne.bpr
@@ -70,7 +70,7 @@
     <DEBUGLIBPATH value="$(BCB)\lib\debug"/>
     <RELEASELIBPATH value="$(BCB)\lib\release"/>
     <LINKER value="tlink32"/>
-    <USERDEFINES value=""/>
+    <USERDEFINES value="_DEBUG"/>
     <SYSDEFINES value="NO_STRICT"/>
     <MAINSOURCE value="EightyOne.cpp"/>
     <INCLUDEPATH value="SP0256;C:\;Display;peripherals\zxprinter;BasicLoader;BasicLister;ProgramLister;Chroma;Spectra;RomCartridge;$(BCB)\include;$(BCB)\include\vcl;zxpand;cr81;1541;IECBus;rzx;zlib\minizip;zlib;1772;ide;libdsk;lib765;Spectrum;Ace;tzx;peripherals;Timer;sound;DebugWin;wavtape;zxprinter;TapeMan;zx81;z80;..\Components\Animation-Timer\lib;&quot;..\Components\Office Button 97\OffBtn97&quot;;&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot;;&quot;..\Components\ComPort Library&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\CBuilder&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot;"/>
@@ -89,12 +89,13 @@
       -I&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot; 
       -I&quot;..\Components\ComPort Library&quot; 
       -I&quot;..\Components\Theme Manager\TMSourceOnly\CBuilder&quot; 
-      -I&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot; -src_suffix cpp -boa"/>
-    <CFLAG1 value="-O2 -Vx -Ve -RT- -X- -a8 -6 -b- -k- -vi -c -tW -tWM"/>
-    <PFLAGS value="-$Y- -$L- -$I- -$D- -$C- -v -JPHNE -M"/>
+      -I&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot; -src_suffix cpp 
+      -D_DEBUG -boa"/>
+    <CFLAG1 value="-Od -Vx -Ve -RT- -X- -r- -a8 -6 -b- -k -y -v -vi- -c -tW -tWM"/>
+    <PFLAGS value="-$Y+ -$W -$O- -$I- -$C- -v -JPHNE -M"/>
     <RFLAGS value=""/>
-    <AFLAGS value="/mx /w2 /zn"/>
-    <LFLAGS value="-D&quot;&quot; -V5.0 -aa -Tpe -x -Gn"/>
+    <AFLAGS value="/mx /w2 /zi"/>
+    <LFLAGS value="-D&quot;&quot; -V5.0 -aa -Tpe -x -Gn -v"/>
   </OPTIONS>
   <LINKER>
     <ALLOBJ value="c0w32.obj sysinit.obj $(OBJFILES)"/>

--- a/Source/EightyOne.bpr
+++ b/Source/EightyOne.bpr
@@ -70,7 +70,7 @@
     <DEBUGLIBPATH value="$(BCB)\lib\debug"/>
     <RELEASELIBPATH value="$(BCB)\lib\release"/>
     <LINKER value="tlink32"/>
-    <USERDEFINES value="_DEBUG"/>
+    <USERDEFINES value=""/>
     <SYSDEFINES value="NO_STRICT"/>
     <MAINSOURCE value="EightyOne.cpp"/>
     <INCLUDEPATH value="SP0256;C:\;Display;peripherals\zxprinter;BasicLoader;BasicLister;ProgramLister;Chroma;Spectra;RomCartridge;$(BCB)\include;$(BCB)\include\vcl;zxpand;cr81;1541;IECBus;rzx;zlib\minizip;zlib;1772;ide;libdsk;lib765;Spectrum;Ace;tzx;peripherals;Timer;sound;DebugWin;wavtape;zxprinter;TapeMan;zx81;z80;..\Components\Animation-Timer\lib;&quot;..\Components\Office Button 97\OffBtn97&quot;;&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot;;&quot;..\Components\ComPort Library&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\CBuilder&quot;;&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot;"/>
@@ -89,13 +89,12 @@
       -I&quot;..\Components\Office Button 97\OffBtn97\32-Bit&quot; 
       -I&quot;..\Components\ComPort Library&quot; 
       -I&quot;..\Components\Theme Manager\TMSourceOnly\CBuilder&quot; 
-      -I&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot; -src_suffix cpp 
-      -D_DEBUG -boa"/>
-    <CFLAG1 value="-Od -Vx -Ve -RT- -X- -r- -a8 -6 -b- -k -y -v -vi- -c -tW -tWM"/>
-    <PFLAGS value="-$Y+ -$W -$O- -$I- -$C- -v -JPHNE -M"/>
+      -I&quot;..\Components\Theme Manager\TMSourceOnly\Source&quot; -src_suffix cpp -boa"/>
+    <CFLAG1 value="-O2 -Vx -Ve -RT- -X- -a8 -6 -b- -k- -vi -c -tW -tWM"/>
+    <PFLAGS value="-$Y- -$L- -$I- -$D- -$C- -v -JPHNE -M"/>
     <RFLAGS value=""/>
-    <AFLAGS value="/mx /w2 /zi"/>
-    <LFLAGS value="-D&quot;&quot; -V5.0 -aa -Tpe -x -Gn -v"/>
+    <AFLAGS value="/mx /w2 /zn"/>
+    <LFLAGS value="-D&quot;&quot; -V5.0 -aa -Tpe -x -Gn"/>
   </OPTIONS>
   <LINKER>
     <ALLOBJ value="c0w32.obj sysinit.obj $(OBJFILES)"/>

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -1290,6 +1290,7 @@ void TForm1::SaveSettings(TIniFile *ini)
         TZX->SaveSettings(ini);
         FSSettings->SaveSettings(ini);
         P3Drive->SaveSettings(ini);
+        SoundOutput->SaveSettings(ini);
         IF1->SaveSettings(ini);
         ParallelPort->SaveSettings(ini);
         MidiForm->SaveSettings(ini);

--- a/Source/sound/SoundDX.cpp
+++ b/Source/sound/SoundDX.cpp
@@ -61,9 +61,8 @@ int CDSnd::Initialise(HWND hWnd, int FPS, int BitsPerSample, int SampleRate, int
         m_WFE.nChannels = (WORD)m_Channels;
         m_WFE.nSamplesPerSec = m_SampleRate;
         m_WFE.wBitsPerSample = (WORD)m_BitsPerSample;
-        m_WFE.nBlockAlign = m_WFE.nChannels;
-        m_WFE.nAvgBytesPerSec = m_WFE.nChannels *
-                        m_WFE.nSamplesPerSec * m_WFE.wBitsPerSample/8;
+        m_WFE.nBlockAlign = (WORD)(m_WFE.nChannels * m_BitsPerSample / 8);
+        m_WFE.nAvgBytesPerSec = m_WFE.nSamplesPerSec * m_WFE.nBlockAlign;
 
         // Calculate Bufferlengths
         // AudioQueue is 2 Seconds long

--- a/Source/sound/SoundForm.cpp
+++ b/Source/sound/SoundForm.cpp
@@ -45,7 +45,7 @@ __fastcall TMidiForm::TMidiForm(TComponent* Owner)
         LoadSettings(ini);
         delete ini;
 
-        Sound.ReInitialise(0, 0, 8, 44100, 2);
+        Sound.ReInitialise(0, 0, 16, 44100, 2);
 }
 //---------------------------------------------------------------------------
 void __fastcall TMidiForm::OKClick(TObject *Sender)

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -84,5 +84,19 @@ void __fastcall TSoundOutput::FormClose(TObject *Sender,
 
 void TSoundOutput::LoadSettings(TIniFile *ini)
 {
+        Top = ini->ReadInteger("SOUNDOP","Top",Top);
+        Left = ini->ReadInteger("SOUNDOP","Left",Left);
+        Height = ini->ReadInteger("SOUNDOP","Height",Height);
+        Width = ini->ReadInteger("SOUNDOP","Width",Width);
+
         if (Form1->SoundOutput1->Checked) Show();
 }
+
+void TSoundOutput::SaveSettings(TIniFile *ini)
+{
+        ini->WriteInteger("SOUNDOP","Top",Top);
+        ini->WriteInteger("SOUNDOP","Left",Left);
+        ini->WriteInteger("SOUNDOP","Height",Height);
+        ini->WriteInteger("SOUNDOP","Width",Width);
+}
+

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -34,7 +34,7 @@
 TSoundOutput *SoundOutput;
 //---------------------------------------------------------------------------
 
-void TSoundOutput::UpdateImage(unsigned char *data, int channels)
+void TSoundOutput::UpdateImage(char *data, int channels, int bytesPerSample)
 {
         long x;
         static int skip=0;
@@ -51,11 +51,12 @@ void TSoundOutput::UpdateImage(unsigned char *data, int channels)
         Img->LineTo(Image1->Width,Image1->Height/2);
 
         Img->Pen->Color = clBlack;
-        Img->MoveTo(0, data[0]/2);
+        int offset=bytesPerSample==2?1:0;
+        Img->MoveTo(0, (data[offset]+128*offset)/2);
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
-                Img->LineTo(x, data[channels*x]/2);
+                Img->LineTo(x, (data[channels*bytesPerSample*x+offset]+128*offset)/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -34,7 +34,7 @@
 TSoundOutput *SoundOutput;
 //---------------------------------------------------------------------------
 
-void TSoundOutput::UpdateImage(char *data, int channels, int bytesPerSample)
+void TSoundOutput::UpdateImage(unsigned char *data, int channels, int bytesPerSample)
 {
         long x;
         static int skip=0;
@@ -52,11 +52,11 @@ void TSoundOutput::UpdateImage(char *data, int channels, int bytesPerSample)
 
         Img->Pen->Color = clBlack;
         int offset=bytesPerSample==2?1:0;
-        Img->MoveTo(0, (data[offset]+128*offset)/2);
+        Img->MoveTo(0, ((data[offset]+128*offset)&0xFF)/2);
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
-                Img->LineTo(x, (data[channels*bytesPerSample*x+offset]+128*offset)/2);
+                Img->LineTo(x, ((data[channels*bytesPerSample*x+offset]+128*offset)&0xFF)/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -43,6 +43,7 @@ public:		// User declarations
         __fastcall TSoundOutput(TComponent* Owner);
         void UpdateImage(unsigned char *data, int channels, int bytesPerSample);
         void LoadSettings(TIniFile *ini);
+        void SaveSettings(TIniFile *ini);
 };
 //---------------------------------------------------------------------------
 extern PACKAGE TSoundOutput *SoundOutput;

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -41,7 +41,7 @@ private:	// User declarations
         TCanvas *Img;
 public:		// User declarations
         __fastcall TSoundOutput(TComponent* Owner);
-        void UpdateImage(char *data, int channels, int bytesPerSample);
+        void UpdateImage(unsigned char *data, int channels, int bytesPerSample);
         void LoadSettings(TIniFile *ini);
 };
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -41,7 +41,7 @@ private:	// User declarations
         TCanvas *Img;
 public:		// User declarations
         __fastcall TSoundOutput(TComponent* Owner);
-        void UpdateImage(unsigned char *data, int channels);
+        void UpdateImage(char *data, int channels, int bytesPerSample);
         void LoadSettings(TIniFile *ini);
 };
 //---------------------------------------------------------------------------

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -94,7 +94,7 @@ int CSound::Initialise(HWND hWnd, int FPS, int BitsPerSample, int SampleRate, in
 
         FrameSize=m_SampleRate/m_FPS;
 
-        Buffer = new char[FrameSize*m_Channels*m_BytesPerSample];
+        Buffer = new BYTE[FrameSize*m_Channels*m_BytesPerSample];
 
         if(Buffer==NULL)
         {
@@ -240,7 +240,7 @@ void CSound::AYOverlay(void)
                 AYChange[f].ofs=(unsigned short)((AYChange[f].tstates*m_SampleRate)/machine.clockspeed);
 
         int offset=m_BytesPerSample==2?1:0;
-        for(f=0,ptr=Buffer+offset;f<FrameSize;f++,ptr+=m_Channels*m_BytesPerSample)
+        for(f=0,ptr=(char *)Buffer+offset;f<FrameSize;f++,ptr+=m_Channels*m_BytesPerSample)
         {
                 // update ay registers. All this sub-frame change stuff
                 // is pretty hairy, but how else would you handle the
@@ -486,7 +486,7 @@ void CSound::Frame(void)
 
         //if(zx81.vsyncsound)
         {
-                ptr=Buffer+m_Channels*FillPos*m_BytesPerSample;
+                ptr=(char *)Buffer+m_Channels*FillPos*m_BytesPerSample;
                 for(f=FillPos;f<FrameSize;f++)
                 {
                         BEEPER_OLDVAL_ADJUST;
@@ -509,7 +509,7 @@ void CSound::Frame(void)
         if (machine.aysound) AYOverlay();
         
         // Overlay speech audio
-        ptr=Buffer;
+        ptr=(char *)Buffer;
         for(f=0;f<FrameSize;f++)
         {
                 int temp = sp0256_AL2.GetNextSample();
@@ -538,7 +538,7 @@ void CSound::Frame(void)
                 }
         }
 
-        DXSound.Frame((unsigned char *)Buffer, FrameSize*m_Channels*m_BytesPerSample);
+        DXSound.Frame(Buffer, FrameSize*m_Channels*m_BytesPerSample);
         SoundOutput->UpdateImage(Buffer,m_Channels,m_BytesPerSample);
 
         OldPos=-1;
@@ -585,7 +585,7 @@ void CSound::Beeper(int on, int frametstates)
         if(newpos>=0)
         {
                 //  fill gap from previous position
-                ptr=Buffer+m_Channels*FillPos*m_BytesPerSample;
+                ptr=(char *)Buffer+m_Channels*FillPos*m_BytesPerSample;
                 for(f=FillPos;f<newpos && f<FrameSize;f++)
                 {
                         BEEPER_OLDVAL_ADJUST;
@@ -604,7 +604,7 @@ void CSound::Beeper(int on, int frametstates)
                 if(newpos<FrameSize)
                 {
                         // newpos may be less than FillPos, so...
-                        ptr=Buffer+m_Channels*newpos*m_BytesPerSample;
+                        ptr=(char *)Buffer+m_Channels*newpos*m_BytesPerSample;
 
                         // limit subval in case of faded beeper level,
                         // to avoid slight spikes on ordinary tones.

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -77,6 +77,7 @@ int CSound::Initialise(HWND hWnd, int FPS, int BitsPerSample, int SampleRate, in
 
         // Otherwise, we're good to go, so configure the sound.
 
+        m_BytesPerSample=m_BitsPerSample/8;
         EnvHeld=0;
         EnvAlternating=0;
         BeeperLastSubpos=0;
@@ -93,7 +94,7 @@ int CSound::Initialise(HWND hWnd, int FPS, int BitsPerSample, int SampleRate, in
 
         FrameSize=m_SampleRate/m_FPS;
 
-        Buffer = new BYTE[FrameSize*m_Channels];
+        Buffer = new char[FrameSize*m_Channels*m_BytesPerSample];
 
         if(Buffer==NULL)
         {
@@ -101,10 +102,9 @@ int CSound::Initialise(HWND hWnd, int FPS, int BitsPerSample, int SampleRate, in
                 return(-1); // Oh dear, malloc failed
         }
 
-        OldVal=OldValOrig=128;
+        OldVal=OldValOrig=0;
         OldPos=-1;
         FillPos=0;
-        SoundPtr=Buffer;
 
         BeeperTick=0;
         BeeperTickIncr=(1<<24)/m_SampleRate;
@@ -223,7 +223,7 @@ void CSound::AYOverlay(void)
         int mixer,envshape;
         int f,g,level;
         int v=0;
-        unsigned char *ptr;
+        char *ptr;
         struct AYChangeTag *change_ptr;
         int changes_left;
         int reg,r;
@@ -239,7 +239,8 @@ void CSound::AYOverlay(void)
         for(f=0;f<AYChangeCount;f++)
                 AYChange[f].ofs=(unsigned short)((AYChange[f].tstates*m_SampleRate)/machine.clockspeed);
 
-        for(f=0,ptr=Buffer;f<FrameSize;f++,ptr+=m_Channels)
+        int offset=m_BytesPerSample==2?1:0;
+        for(f=0,ptr=Buffer+offset;f<FrameSize;f++,ptr+=m_Channels*m_BytesPerSample)
         {
                 // update ay registers. All this sub-frame change stuff
                 // is pretty hairy, but how else would you handle the
@@ -468,30 +469,37 @@ void CSound::AYReset(void)
   if(BeeperTick>=BEEPER_FADEOUT)	\
     {					\
     BeeperTick-=BEEPER_FADEOUT;	\
-    if(OldVal>128)		\
+    if(OldVal>0)		\
       OldVal--;			\
     else				\
-      if(OldVal<128)		\
+      if(OldVal<0)		\
         OldVal++;			\
     }
 
 
 void CSound::Frame(void)
 {                  
-        unsigned char *ptr;
+        char *ptr;
         int f;
 
         // if(!sound_enabled) return;
 
         //if(zx81.vsyncsound)
         {
-                ptr=Buffer+(m_Channels*FillPos);
+                ptr=Buffer+m_Channels*FillPos*m_BytesPerSample;
                 for(f=FillPos;f<FrameSize;f++)
                 {
                         BEEPER_OLDVAL_ADJUST;
-                        *ptr++=(unsigned char)OldVal;
+                        if (m_BytesPerSample==2)
+                                *ptr++=0;
+                        *ptr++=OldVal;
+
                         if(m_Channels == 2)
-                                *ptr++=(unsigned char)OldVal;
+                        {
+                                if (m_BytesPerSample==2)
+                                        *ptr++=0;
+                                *ptr++=OldVal;
+                        }
                 }
         }
         //else
@@ -499,37 +507,56 @@ void CSound::Frame(void)
         //        memset(Buffer,128,FrameSize*m_Channels);
 
         if (machine.aysound) AYOverlay();
-
+        
         // Overlay speech audio
         ptr=Buffer;
         for(f=0;f<FrameSize;f++)
         {
-                char temp = ((sp0256_AL2.GetNextSample()/256)*VolumeLevel[4])/31;
-                *(ptr++)+=temp;
-                if(m_Channels == 2)
-                        *(ptr++)+=temp;
+                int temp = sp0256_AL2.GetNextSample();
+                temp = (temp*VolumeLevel[4])/31;
+                if (m_BytesPerSample==2)
+                {
+                        int buffval = *ptr + (*(ptr+1))*256;
+                        buffval+=temp;
+                        *(ptr++)=buffval & 0xFF;
+                        *(ptr++)=buffval/256 & 0xFF;
+                        if(m_Channels == 2)
+                        {
+                                *(ptr++)=buffval & 0xFF;
+                                *(ptr++)=buffval/256 & 0xFF;
+                        }
+                }
+                else
+                {
+                        int buffval = *ptr;
+                        buffval+=temp/256;
+                        *(ptr++)=(buffval+128) & 0xFF;
+                        if(m_Channels == 2)
+                        {
+                                *(ptr++)=(buffval+128) & 0xFF;
+                        }
+                }
         }
 
-        DXSound.Frame(Buffer, FrameSize*m_Channels);
-        SoundOutput->UpdateImage(Buffer,m_Channels);
+        DXSound.Frame((unsigned char *)Buffer, FrameSize*m_Channels*m_BytesPerSample);
+        SoundOutput->UpdateImage(Buffer,m_Channels,m_BytesPerSample);
 
         OldPos=-1;
         FillPos=0;
-        SoundPtr=Buffer;
 
         AYChangeCount=0;
 }
 
 void CSound::Beeper(int on, int frametstates)
 {                                     
-        unsigned char *ptr;
+        char *ptr;
         int newpos,subpos;
         int val,subval;
         int f;
 
         // if(!sound_enabled) return;
 
-        val=(on?128+VolumeLevel[3]:128-VolumeLevel[3]);
+        val=(on?0+VolumeLevel[3]:0-VolumeLevel[3]);
 
         if(val==OldValOrig) return;
 
@@ -553,36 +580,49 @@ void CSound::Beeper(int on, int frametstates)
         else
                 BeeperLastSubpos=(on?VolumeLevel[3]-subpos:subpos);
 
-        subval=128-AMPL_BEEPER+BeeperLastSubpos;
+        subval=0-AMPL_BEEPER+BeeperLastSubpos;
 
         if(newpos>=0)
         {
                 //  fill gap from previous position
-                ptr=Buffer+(m_Channels*FillPos);
+                ptr=Buffer+m_Channels*FillPos*m_BytesPerSample;
                 for(f=FillPos;f<newpos && f<FrameSize;f++)
                 {
                         BEEPER_OLDVAL_ADJUST;
-                        *ptr++=(unsigned char)OldVal;
+                        if (m_BytesPerSample==2)
+                                *ptr++=0;
+                        *ptr++=OldVal;
+
                         if(m_Channels==2)
-                        *ptr++=(unsigned char)OldVal;
+                        {
+                                if (m_BytesPerSample==2)
+                                        *ptr++=0;
+                                *ptr++=OldVal;
+                        }
                 }
 
                 if(newpos<FrameSize)
                 {
                         // newpos may be less than FillPos, so...
-                        ptr=Buffer+(m_Channels*newpos);
+                        ptr=Buffer+m_Channels*newpos*m_BytesPerSample;
 
                         // limit subval in case of faded beeper level,
                         // to avoid slight spikes on ordinary tones.
 
-                        if((OldVal<128 && subval<OldVal) ||
-                                (OldVal>=128 && subval>OldVal))
+                        if((OldVal<0 && subval<OldVal) ||
+                                (OldVal>=0 && subval>OldVal))
                                         subval=OldVal;
 
                         // write subsample value
-                        *ptr=(unsigned char)subval;
+                        if (m_BytesPerSample==2)
+                                *ptr++=0;
+                        *ptr=subval;
                         if(m_Channels==2)
-                        *++ptr=(unsigned char)subval;
+                        {
+                                if (m_BytesPerSample==2)
+                                        *ptr++=0;
+                                *ptr=subval;
+                        }
                 }
         }
 

--- a/Source/sound/sound.h
+++ b/Source/sound/sound.h
@@ -112,7 +112,7 @@ private:
         int FramesPerSecond;
 
         unsigned char AYToneLevels[16];
-        char *Buffer;
+        unsigned char *Buffer;
         int OldPos,FillPos,OldVal,OldValOrig;
 
 	// timer used for fadeout after beeper-toggle;

--- a/Source/sound/sound.h
+++ b/Source/sound/sound.h
@@ -100,6 +100,7 @@ private:
 
         HWND m_hWnd;
         int m_BitsPerSample;
+        int m_BytesPerSample;
         int m_SampleRate;
         int m_Channels;
         int m_FPS;
@@ -111,8 +112,7 @@ private:
         int FramesPerSecond;
 
         unsigned char AYToneLevels[16];
-        unsigned char *Buffer;
-        unsigned char *SoundPtr;
+        char *Buffer;
         int OldPos,FillPos,OldVal,OldValOrig;
 
 	// timer used for fadeout after beeper-toggle;


### PR DESCRIPTION
Currently, EO generates 8-bit sound output, which introduces some noise independent of the sounds we are intentionally generating. DirectSound also support 16-bit data, which aligns well with modern PCs. The sound generator was updated to utilize 16-bit sound output to improve sound performance.
Also added saving and restoring of the Sound Output form in the INI file.