### PR TITLE
Fixed AY emulation behavior

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -29,6 +29,9 @@ Version 1.41 - 11/01/2025 (by Paul Farrow and John Stroebel)
   - Corrected ROM path for the MWCFide IDE drive.
   - The BASIC Listing loader was not tokenising "" within REM statements on the ZX81 when
     tokenisation of REM contents was enabled.
+  - Fixed AY sound implementation to align with hardware behavior.
+  - Fixed AY sound controls.
+  - Fixed ACP stereo mode operation and beeper feedback.
 * Changes:
   - Renamed the 'Discard Redundant Spaces' option of the BASIC Listing loader to be 'Discard
     Surplus Spaces'.
@@ -38,6 +41,7 @@ Version 1.41 - 11/01/2025 (by Paul Farrow and John Stroebel)
   - Removed unused non-functioning QL emulation.
   - The Sound dropdown in the Hardware dialog now presents options applicable to the selected
     computer.
+  - Switched from 8-bit to 16-bit sound generation.
 * Enhancements:
   - Separated and updated the documentation for CHR$128 mode and the ARX true high resolution
     display mechanism.

--- a/Source/sound/SoundForm.cpp
+++ b/Source/sound/SoundForm.cpp
@@ -45,7 +45,6 @@ __fastcall TMidiForm::TMidiForm(TComponent* Owner)
         LoadSettings(ini);
         delete ini;
 
-        zx81.beeperExcludeHSyncs = BeeperExcludeHSyncs->Checked;
         Sound.ReInitialise(0, 0, 16, 44100, 2);
 }
 //---------------------------------------------------------------------------
@@ -64,6 +63,9 @@ void __fastcall TMidiForm::FormDestroy(TObject *Sender)
 void __fastcall TMidiForm::MidiChange(TObject *Sender)
 {
         static int LastMidiItem=0;
+
+        //BeeperExcludeHSyncs->Enabled=!RadioButtonACB->Checked;
+        //BeeperExcludeHSyncs->Checked=RadioButtonACB->Checked?true:zx81.beeperExcludeHSyncs;
 
         Sound.VolumeLevel[0]= AYMute->Checked ? 0:ChAVol->Max - ChAVol->Position;
         Sound.VolumeLevel[1]= AYMute->Checked ? 0:ChBVol->Max - ChBVol->Position;
@@ -115,9 +117,9 @@ void TMidiForm::LoadSettings(TIniFile *ini)
         RadioButtonACB->Checked=ini->ReadBool("MIDI","AYMixACB",RadioButtonACB->Checked);
         BeeperExcludeHSyncs->Checked=ini->ReadBool("MIDI","BeeperExcludeHSyncs",BeeperExcludeHSyncs->Checked);
 
-        OKClick(NULL);
+        zx81.beeperExcludeHSyncs = BeeperExcludeHSyncs->Checked;
 
-        MidiChange(NULL);
+        OKClick(NULL);
 }
 
 void __fastcall TMidiForm::BeeperExcludeHSyncsClick(TObject *Sender)

--- a/Source/sound/SoundForm.cpp
+++ b/Source/sound/SoundForm.cpp
@@ -45,6 +45,7 @@ __fastcall TMidiForm::TMidiForm(TComponent* Owner)
         LoadSettings(ini);
         delete ini;
 
+        zx81.beeperExcludeHSyncs = BeeperExcludeHSyncs->Checked;
         Sound.ReInitialise(0, 0, 16, 44100, 2);
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundForm.cpp
+++ b/Source/sound/SoundForm.cpp
@@ -64,9 +64,6 @@ void __fastcall TMidiForm::MidiChange(TObject *Sender)
 {
         static int LastMidiItem=0;
 
-        //BeeperExcludeHSyncs->Enabled=!RadioButtonACB->Checked;
-        //BeeperExcludeHSyncs->Checked=RadioButtonACB->Checked?true:zx81.beeperExcludeHSyncs;
-
         Sound.VolumeLevel[0]= AYMute->Checked ? 0:ChAVol->Max - ChAVol->Position;
         Sound.VolumeLevel[1]= AYMute->Checked ? 0:ChBVol->Max - ChBVol->Position;
         Sound.VolumeLevel[2]= AYMute->Checked ? 0:ChCVol->Max - ChCVol->Position;

--- a/Source/sound/SoundForm.dfm
+++ b/Source/sound/SoundForm.dfm
@@ -202,6 +202,7 @@ object MidiForm: TMidiForm
       Checked = True
       TabOrder = 6
       TabStop = True
+      OnClick = MidiChange
     end
     object RadioButtonACB: TRadioButton
       Left = 224
@@ -210,6 +211,7 @@ object MidiForm: TMidiForm
       Height = 17
       Caption = 'ACB'
       TabOrder = 7
+      OnClick = MidiChange
     end
     object SpeechMute: TCheckBox
       Left = 180

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -34,7 +34,7 @@
 TSoundOutput *SoundOutput;
 //---------------------------------------------------------------------------
 
-void TSoundOutput::UpdateImage(unsigned char *data, int channels, int bytesPerSample)
+void TSoundOutput::UpdateImage(short *data, int channels)
 {
         long x;
         static int skip=0;
@@ -51,16 +51,15 @@ void TSoundOutput::UpdateImage(unsigned char *data, int channels, int bytesPerSa
         Img->LineTo(Image1->Width,Image1->Height/2);
 
         Img->Pen->Color = clBlack;
-        int offset=bytesPerSample==2?1:0;
-        Img->MoveTo(0, (((char)data[offset]+128*offset)&0xFF)/2);
+        Img->MoveTo(0, ((data[0]/256+128)&0xFF)/2);
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
                 int currval=0;
                 for (int i=1;i<=channels;i++)
-                        currval+=(char)data[i*bytesPerSample*x+offset];
+                        currval+=data[i*x];
 
-                Img->LineTo(x, ((currval+128*offset)&0xFF)/2);
+                Img->LineTo(x, ((currval/256+128)&0xFF)/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -52,11 +52,15 @@ void TSoundOutput::UpdateImage(unsigned char *data, int channels, int bytesPerSa
 
         Img->Pen->Color = clBlack;
         int offset=bytesPerSample==2?1:0;
-        Img->MoveTo(0, ((data[offset]+128*offset)&0xFF)/2);
+        Img->MoveTo(0, (((char)data[offset]+128*offset)&0xFF)/2);
         for (x=0; x<Image1->Width; x++)
         {
                 //Img->MoveTo(x,64);
-                Img->LineTo(x, ((data[channels*bytesPerSample*x+offset]+128*offset)&0xFF)/2);
+                int currval=0;
+                for (int i=1;i<=channels;i++)
+                        currval+=(char)data[i*bytesPerSample*x+offset];
+
+                Img->LineTo(x, ((currval+128*offset)&0xFF)/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -41,7 +41,7 @@ private:	// User declarations
         TCanvas *Img;
 public:		// User declarations
         __fastcall TSoundOutput(TComponent* Owner);
-        void UpdateImage(unsigned char *data, int channels, int bytesPerSample);
+        void UpdateImage(short *data, int channels);
         void LoadSettings(TIniFile *ini);
         void SaveSettings(TIniFile *ini);
 };

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -357,7 +357,7 @@ void CSound::AYOverlay(void)
                                 // chan c shouldn't be full vol on both channels
                                 int atv = *ptr * 3/4;
                                 ptr[0]=(unsigned char)atv;
-                                ptr[1]=(unsigned char)atv;
+                                ptr[1*m_BytesPerSample]=(unsigned char)atv;
                         }
                 }
                 if((mixer&1)==0 || (mixer&0x08)==0)
@@ -372,11 +372,11 @@ void CSound::AYOverlay(void)
                         // channel B
                         level=(noise_toggle || (mixer&0x10))?tone_level[1]:0;
                         level=(level*VolumeLevel[0])/31;
-                        AY_OVERLAY_TONE(ptr+(ACBMix?1:0),1,level);
+                        AY_OVERLAY_TONE(ptr+(ACBMix?1:0)*m_BytesPerSample,1,level);
                 }
 
                 if(!ACBMix)
-                        ptr[1]=*ptr;
+                        ptr[1*m_BytesPerSample]=*ptr;
 
                 // update noise RNG/filter
                 AYNoiseTick+=AYTickIncr;

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -426,7 +426,7 @@ void CSound::AYOverlay(void)
                                 ch1+=level;
                 }
 
-                if(!ch2Updated)
+                if(!stereo && !ch2Updated)
                         ch2=ch1;
 
                 Buffer[f*m_Channels]+=ch1;

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -393,7 +393,7 @@ void CSound::AYOverlay(void)
                 {
                         // channel C
                         level=noise_toggle?tone_level[2]:0;
-                        level=(level*VolumeLevel[2])/31;
+                        level=(256*level*VolumeLevel[2])/31;
                         if(stereo)
                         {
                                 // chan c shouldn't be full vol on both channels
@@ -409,14 +409,14 @@ void CSound::AYOverlay(void)
                 {
                         // channel A
                         level=noise_toggle?tone_level[0]:0;
-                        level=(level*VolumeLevel[0])/31;
+                        level=(256*level*VolumeLevel[0])/31;
                         ch1+=level;
                 }
                 if((mixer&0x10)==0)
                 {
                         // channel B
                         level=noise_toggle?tone_level[1]:0;
-                        level=(level*VolumeLevel[1])/31;
+                        level=(256*level*VolumeLevel[1])/31;
                         if (stereo)
                         {
                                 ch2+=level;
@@ -494,7 +494,6 @@ void CSound::AYReset(void)
         for(f=0;f<16;f++)
                 AYWrite(f,0,0);
 
-        AYWrite(7,255,0);
         AYOverlay();
 }
 

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -426,7 +426,7 @@ void CSound::AYOverlay(void)
                                 ch1+=level;
                 }
 
-                if(!stereo && !ch2Updated)
+                if(!stereo)
                         ch2=ch1;
 
                 Buffer[f*m_Channels]+=ch1;

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -232,6 +232,7 @@ void CSound::AYOverlay(void)
 
         change_ptr=AYChange;
         changes_left=AYChangeCount;
+        bool stereo = (m_Channels==2)&&ACBMix;
 
         // If no AY chip, don't produce any AY sound (!)
         //if(!sound_ay) return;
@@ -352,7 +353,7 @@ void CSound::AYOverlay(void)
                         // channel C
                         level=(tone_level[2]*VolumeLevel[2])/31;
                         AY_OVERLAY_TONE(ptr,2,level);
-                        if(ACBMix)
+                        if(stereo)
                         {
                                 // chan c shouldn't be full vol on both channels
                                 char atv = *ptr * 3/4;
@@ -370,7 +371,7 @@ void CSound::AYOverlay(void)
                 {
                         // channel B
                         level=(tone_level[1]*VolumeLevel[1])/31;
-                        AY_OVERLAY_TONE(ptr+(ACBMix?1:0)*m_BytesPerSample,1,level);
+                        AY_OVERLAY_TONE(ptr+(stereo?1:0)*m_BytesPerSample,1,level);
                 }
 
                 // generate noise
@@ -393,10 +394,10 @@ void CSound::AYOverlay(void)
                         // channel B
                         level=noise_toggle?tone_level[1]:0;
                         level=(level*VolumeLevel[1])/31;
-                        ptr[(ACBMix?1:0)*m_BytesPerSample]+=level;
+                        ptr[(stereo?1:0)*m_BytesPerSample]+=level;
                 }
 
-                if(!ACBMix)
+                if(!stereo&&(m_Channels==2))
                         ptr[1*m_BytesPerSample]=*ptr;
 
                 // update noise RNG/filter

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -348,7 +348,6 @@ void CSound::AYOverlay(void)
                 // channel C first to make ACB easier
                 int ch1=0;
                 int ch2=0;
-                bool ch2Updated=false;
                 mixer=AYRegisters[7];
                 if((mixer&4)==0)
                 {
@@ -362,7 +361,6 @@ void CSound::AYOverlay(void)
                                 int atv = tempval * 3/4;
                                 ch1+=atv;
                                 ch2+=atv;
-                                ch2Updated=true;
                         }
                         else
                                 ch1+=tempval;
@@ -380,7 +378,6 @@ void CSound::AYOverlay(void)
                         if (stereo)
                         {
                                 AY_OVERLAY_TONE(ch2,1,level);
-                                ch2Updated=true;
                         }
                         else
                         {
@@ -400,7 +397,6 @@ void CSound::AYOverlay(void)
                                 int atv = level * 3/4;
                                 ch1+=atv;
                                 ch2+=atv;
-                                ch2Updated=true;
                         }
                         else
                                 ch1+=level;
@@ -420,7 +416,6 @@ void CSound::AYOverlay(void)
                         if (stereo)
                         {
                                 ch2+=level;
-                                ch2Updated=true;
                         }
                         else
                                 ch1+=level;

--- a/Source/sound/sound.h
+++ b/Source/sound/sound.h
@@ -112,7 +112,7 @@ private:
         int FramesPerSecond;
 
         unsigned char AYToneLevels[16];
-        unsigned char *Buffer;
+        short *Buffer;
         int OldPos,FillPos,OldVal,OldValOrig;
 
 	// timer used for fadeout after beeper-toggle;

--- a/Source/sound/sound.h
+++ b/Source/sound/sound.h
@@ -138,7 +138,6 @@ private:
         unsigned char AYRegisterStore[16];
         struct AYChangeTag AYChange[AY_CHANGE_MAX];
         int AYChangeCount;
-        unsigned int FineValue, CoarseValue, TonePeriod;
 
 };
 


### PR DESCRIPTION
The AY emulation should now be fully functional including ACB stereo mode. This should address issue #51.
Also, now pick up and apply user change to stereo mode as it happens.