### PR TITLE
Sound output waveform window is resizeable

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -44,6 +44,7 @@ Version 1.41 - 17/01/2025 (by Paul Farrow and John Stroebel)
     computer.
   - Switched from 8-bit to 16-bit sound generation.
   - Added support for MIDI output to Spectrum 128k and +2.
+  - Default sound volume settings are in the middle of the range.
 * Enhancements:
   - Separated and updated the documentation for CHR$128 mode and the ARX true high resolution
     display mechanism.

--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -4,7 +4,7 @@ This can be done manually or via Options > Configuration > Reset To Default Sett
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Version 1.41 - 16/01/2025 (by Paul Farrow and John Stroebel)
+Version 1.41 - 17/01/2025 (by Paul Farrow and John Stroebel)
 * Bug fixes:
   - If a hardware generated ZX81 HSync pulse is output part way through a scanline then it is no
     longer interpreted as starting a new scanline.
@@ -57,6 +57,7 @@ Version 1.41 - 16/01/2025 (by Paul Farrow and John Stroebel)
   - Added example programs for ZX Spectrum specific interfaces.
   - Added the manual for the Multiface 3.
   - Added volume controls for speech interface sounds.
+  - Sound output window is resizeable.
 
 Version 1.40 - 07/02/2024 (by Paul Farrow)
 * Bug fixes:

--- a/Source/sound/SoundForm.dfm
+++ b/Source/sound/SoundForm.dfm
@@ -121,7 +121,7 @@ object MidiForm: TMidiForm
       Max = 31
       Orientation = trVertical
       Frequency = 16
-      Position = 0
+      Position = 16
       SelEnd = 0
       SelStart = 0
       TabOrder = 0
@@ -137,7 +137,7 @@ object MidiForm: TMidiForm
       Max = 31
       Orientation = trVertical
       Frequency = 16
-      Position = 0
+      Position = 16
       SelEnd = 0
       SelStart = 0
       TabOrder = 1
@@ -153,7 +153,7 @@ object MidiForm: TMidiForm
       Max = 31
       Orientation = trVertical
       Frequency = 16
-      Position = 0
+      Position = 16
       SelEnd = 0
       SelStart = 0
       TabOrder = 2
@@ -169,7 +169,7 @@ object MidiForm: TMidiForm
       Max = 31
       Orientation = trVertical
       Frequency = 16
-      Position = 0
+      Position = 16
       SelEnd = 0
       SelStart = 0
       TabOrder = 3
@@ -248,7 +248,7 @@ object MidiForm: TMidiForm
     Max = 31
     Orientation = trVertical
     Frequency = 16
-    Position = 0
+    Position = 16
     SelEnd = 0
     SelStart = 0
     TabOrder = 4

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -37,7 +37,6 @@ TSoundOutput *SoundOutput;
 void TSoundOutput::UpdateImage(short *data, int channels, int framesize)
 {
         long x;
-        int f;
         static int skip=0;
 
         if (++skip <3) return;
@@ -52,32 +51,32 @@ void TSoundOutput::UpdateImage(short *data, int channels, int framesize)
         Img->LineTo(Image1->Width,Image1->Height/2);
 
         Img->Pen->Color = clBlack;
-        for (x=0,f=0; x<Image1->Width; x++,f+=framesize/Image1->Width)
+        for (x=0; x<framesize; x++)
         {
                 //Img->MoveTo(x,64);
                 int currval=0;
                 for (int i=0;i<channels;i++)
-                        currval+=(int)data[channels*f+i];
+                        currval+=(int)data[channels*x+i];
 
+                int position=Image1->Height*((double)currval/channels/32768+1)/2;
                 if (x==0)
-                        Img->MoveTo(0, ((currval/channels/256)+Image1->Height)/2);
+                        Img->MoveTo(0, position);
                 else
-                        Img->LineTo(x, ((currval/channels/256)+Image1->Height)/2);
+                        Img->LineTo(x*Image1->Width/framesize, position);
         }
 }
 //---------------------------------------------------------------------------
 __fastcall TSoundOutput::TSoundOutput(TComponent* Owner)
         : TForm(Owner)
 {
-        Img=Image1->Canvas;
-        rect.Top=0; rect.Left=0;
-        rect.Right=Image1->Width; rect.Bottom=Image1->Height;
-        //ClearImage();
+        Img=this->Canvas;
 
         TIniFile *ini;
         ini = new TIniFile(emulator.inipath);
         LoadSettings(ini);
         delete ini;
+
+        FormResize(NULL);
 }
 //---------------------------------------------------------------------------
 
@@ -105,4 +104,13 @@ void TSoundOutput::SaveSettings(TIniFile *ini)
         ini->WriteInteger("SOUNDOP","Height",Height);
         ini->WriteInteger("SOUNDOP","Width",Width);
 }
+
+void __fastcall TSoundOutput::FormResize(TObject *Sender)
+{
+        Image1->Height=this->ClientHeight;
+        Image1->Width=this->ClientWidth;
+        rect.Top=0; rect.Left=0;
+        rect.Right=Image1->Width; rect.Bottom=Image1->Height;
+}
+//---------------------------------------------------------------------------
 

--- a/Source/sound/SoundOP.cpp
+++ b/Source/sound/SoundOP.cpp
@@ -60,9 +60,9 @@ void TSoundOutput::UpdateImage(short *data, int channels, int framesize)
                         currval+=(int)data[channels*f+i];
 
                 if (x==0)
-                        Img->MoveTo(0, ((currval/channels/256)+128)/2);
+                        Img->MoveTo(0, ((currval/channels/256)+Image1->Height)/2);
                 else
-                        Img->LineTo(x, ((currval/channels/256)+128)/2);
+                        Img->LineTo(x, ((currval/channels/256)+Image1->Height)/2);
         }
 }
 //---------------------------------------------------------------------------

--- a/Source/sound/SoundOP.dfm
+++ b/Source/sound/SoundOP.dfm
@@ -1,11 +1,14 @@
 object SoundOutput: TSoundOutput
   Left = 466
   Top = 112
-  BorderStyle = bsToolWindow
+  HorzScrollBar.Visible = False
+  VertScrollBar.Visible = False
   Caption = 'Sound Output'
   ClientHeight = 128
   ClientWidth = 441
   Color = clBtnFace
+  Constraints.MinHeight = 150
+  Constraints.MinWidth = 150
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
   Font.Height = -11
@@ -14,6 +17,7 @@ object SoundOutput: TSoundOutput
   OldCreateOrder = False
   Scaled = False
   OnClose = FormClose
+  OnResize = FormResize
   PixelsPerInch = 96
   TextHeight = 13
   object Image1: TImage

--- a/Source/sound/SoundOP.h
+++ b/Source/sound/SoundOP.h
@@ -36,6 +36,7 @@ class TSoundOutput : public TForm
 __published:	// IDE-managed Components
         TImage *Image1;
         void __fastcall FormClose(TObject *Sender, TCloseAction &Action);
+        void __fastcall FormResize(TObject *Sender);
 private:	// User declarations
         TRect rect;
         TCanvas *Img;


### PR DESCRIPTION
- Made the sound output waveform window resizable so that the signal scales with the window.
- Changed default sound volume settings.
- Updated release notes
