### PR TITLE
Fix speech device read port behavior for ZX80

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -32,7 +32,7 @@ Version 1.41 - 19/01/2025 (by Paul Farrow and John Stroebel)
   - Fixed AY sound controls.
   - Fixed ACP stereo mode operation and beeper feedback.
   - Fixed beeper volume control and addressed noise spikes at low volumes.
-  - Fixed missing " key for Sepctrum 128+ keyboards.
+  - Fixed missing " key for the Spectrum 128 and all Amstrad keyboards.
   - Memotech hi-res didn't support a pixel byte of $76 within the hi-res display file.
 * Changes:
   - Renamed the 'Discard Redundant Spaces' option of the BASIC Listing loader to be 'Discard

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -1322,7 +1322,7 @@ BYTE ReadInputPort(int Address, int *tstates)
 
                 // Note that the Parrot only decodes A7, A5, and A4.
                 //  If these are all 0, then the Parrot performs I/O.
-                if ((machine.speech == SPEECH_TYPE_PARROT) && ((Address&0xB0)==0)) return sp0256_AL2.Busy() ? (BYTE)(idleDataBus & 0xFE) : idleDataBus;
+                if ((machine.speech == SPEECH_TYPE_PARROT) && ((Address&0xB0)==0)) return sp0256_AL2.Busy() ? (BYTE)(idleDataBus & 0xFE) : (BYTE)(idleDataBus | 0x01);
 
                 switch(Address&255)
                 {
@@ -1343,7 +1343,7 @@ BYTE ReadInputPort(int Address, int *tstates)
                         return 0;
 
                 case 0x3f:
-                        if (machine.speech == SPEECH_TYPE_MAGECO) return sp0256_AL2.Busy() ? (BYTE)(idleDataBus & 0xFE) : idleDataBus;
+                        if (machine.speech == SPEECH_TYPE_MAGECO) return sp0256_AL2.Busy() ? (BYTE)(idleDataBus & 0xFE) : (BYTE)(idleDataBus | 0x01);
                         break;
 
                 case 0x41:


### PR DESCRIPTION
- The "device busy" lines for the Mageco and Parrot need to be able to drive the output high to indicate completion. The current implementation tri-stated the output in this case, which is a problem on the ZX80 since its idle data bus is pulled low.
- Fixed a typo in the release notes.