### PR TITLE
Fixed missing internal parameter assignment

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -402,6 +402,7 @@ void THW::SaveInternalSettings()
         Hwform.FDCItemIndex=FDC->ItemIndex;
         Hwform.AutobootChecked=Autoboot->Checked;
         Hwform.ZXpandChecked=ZXpand->Checked;
+        Hwform.ZXpandEnabled=ZXpand->Enabled;
         Hwform.ProtectROMChecked=ProtectROM->Checked;
         Hwform.NTSCChecked=NTSC->Checked;
         Hwform.EnableLowRAMChecked=EnableLowRAM->Checked;


### PR DESCRIPTION
The internally stored value of ZXpand->Enabled was not being stored. This caused the settings to be enabled when it shouldn't be (ex., when Spectrums are the current running machine).