### PR TITLE
Fixed temporary HW settings being saved on program exit and added Cancel

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -3610,3 +3610,9 @@ void __fastcall THW::SpeechBoxChange(TObject *Sender)
 }
 //---------------------------------------------------------------------------
 
+void __fastcall THW::FormClose(TObject *Sender, TCloseAction &Action)
+{
+        ReloadFromInternalSettings();
+}
+//---------------------------------------------------------------------------
+

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -3616,3 +3616,9 @@ void __fastcall THW::FormClose(TObject *Sender, TCloseAction &Action)
 }
 //---------------------------------------------------------------------------
 
+void __fastcall THW::CancelClick(TObject *Sender)
+{
+        Close();        
+}
+//---------------------------------------------------------------------------
+

--- a/Source/HW_.dfm
+++ b/Source/HW_.dfm
@@ -1313,6 +1313,7 @@ object HW: THW
     Caption = 'Cancel'
     Default = True
     TabOrder = 4
+    OnClick = CancelClick
   end
   object RamPackBox: TComboBox
     Left = 169

--- a/Source/HW_.dfm
+++ b/Source/HW_.dfm
@@ -14,6 +14,7 @@ object HW: THW
   Font.Style = []
   OldCreateOrder = False
   Scaled = False
+  OnClose = FormClose
   OnCreate = FormCreate
   OnShow = FormShow
   PixelsPerInch = 96
@@ -1293,7 +1294,7 @@ object HW: THW
     end
   end
   object OK: TButton
-    Left = 329
+    Left = 249
     Top = 339
     Width = 75
     Height = 25
@@ -1302,6 +1303,16 @@ object HW: THW
     Default = True
     TabOrder = 3
     OnClick = OKClick
+  end
+  object Cancel: TButton
+    Left = 329
+    Top = 339
+    Width = 75
+    Height = 25
+    Anchors = [akRight, akBottom]
+    Caption = 'Cancel'
+    Default = True
+    TabOrder = 4
   end
   object RamPackBox: TComboBox
     Left = 169

--- a/Source/HW_.h
+++ b/Source/HW_.h
@@ -229,6 +229,7 @@ __published:	// IDE-managed Components
         void __fastcall ZXpandEmulationInfoClick(TObject *Sender);
         void __fastcall SpeechBoxChange(TObject *Sender);
         void __fastcall FormClose(TObject *Sender, TCloseAction &Action);
+        void __fastcall CancelClick(TObject *Sender);
 private:	// User declarations
         int RamPackHeight;
         int NewMachine, NewSpec;

--- a/Source/HW_.h
+++ b/Source/HW_.h
@@ -228,6 +228,7 @@ __published:	// IDE-managed Components
         void __fastcall TC2068RomCartridgeFileBoxChange(TObject *Sender);
         void __fastcall ZXpandEmulationInfoClick(TObject *Sender);
         void __fastcall SpeechBoxChange(TObject *Sender);
+        void __fastcall FormClose(TObject *Sender, TCloseAction &Action);
 private:	// User declarations
         int RamPackHeight;
         int NewMachine, NewSpec;


### PR DESCRIPTION
The internal hardware settings were not being properly refreshed when the HW box is canceled.
Added the Cancel button.