### PR TITLE
Update cursor mode when a new machine is selected

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -244,7 +244,7 @@ void THW::UpdateHardwareSettings(bool reinitialise, bool disableReset)
         AccurateInit(false);
         Speed->Recalc(NULL);
         PCKbInit();
-        Kb->OKClick(NULL);
+        Kb->UpdateCursors();
 
         if (ResetRequired && !disableReset)
         {

--- a/Source/kb_.cpp
+++ b/Source/kb_.cpp
@@ -135,6 +135,22 @@ void TKb::SaveSettings(TIniFile *ini)
         ini->WriteBool("KB","RIGHTSHIFT", CheckBox1->Checked);
 }
 
+void TKb::UpdateCursors()
+{
+        if (emulator.machine==MACHINELAMBDA && CursorMode->ItemIndex!=3)
+        {
+                CursorMode->ItemIndex=3;
+        }
+        else
+        {
+                CursorMode->ItemIndex=1;
+
+        }
+
+        CursorModeChange(NULL);
+        OKClick(NULL);
+}
+
 void __fastcall TKb::FormShow(TObject *Sender)
 {
         if (emulator.machine==MACHINESPECTRUM

--- a/Source/kb_.h
+++ b/Source/kb_.h
@@ -52,6 +52,7 @@ public:		// User declarations
         __fastcall TKb(TComponent* Owner);
         void LoadSettings(TIniFile *ini);
         void SaveSettings(TIniFile *ini);
+        void UpdateCursors();
 };
 //---------------------------------------------------------------------------
 extern PACKAGE TKb *Kb;


### PR DESCRIPTION
This facilitates using the Lambda cursor keys when necessary versus switching them manually. Also, one might expect the cursor mode to change when selecting a new machine.