### PR TITLE
Updated sound initialization behavior

### DIFF
--- a/Source/Ace/ace.cpp
+++ b/Source/Ace/ace.cpp
@@ -88,7 +88,6 @@ void ace_initialise()
         tStatesCount = 0;
 
         insertWaitsWhileSP0256Busy = false;
-        sp0256_AL2.Reset();
 
         ResetLastIOAccesses();
 

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -340,7 +340,6 @@ void spec48_initialise()
         spectrum.drivebusy = -1;
 
         insertWaitsWhileSP0256Busy = false;
-        sp0256_AL2.Reset();
         
         z80_init();
         tStatesCount = 0;

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -630,7 +630,7 @@ void __fastcall TForm1::LoadSnapshot1Click(TObject *Sender)
         }
 
         emulation_stop=1;
-        Sound.AYReset();
+        Sound.InitDevices();
 
         if (BasicLister->ListerAvailable())
         {
@@ -685,7 +685,7 @@ void __fastcall TForm1::ResetZX811Click(TObject *Sender)
         PCAllKeysUp();
         emulation_stop=1;
         z80_reset();
-        Sound.AYReset();
+        if (machine.aytype==AY_TYPE_SINCLAIR) Sound.AYReset();
         InitialiseChroma();
         DisableSpectra();
         Dbg->ClearSkipAddresses();
@@ -1387,7 +1387,7 @@ void __fastcall TForm1::HardReset1Click(TObject *Sender)
         z80_reset();
         AccurateInit(false);
         machine.initialise();
-        Sound.AYReset();
+        Sound.InitDevices();
         emulation_stop=initialStopState;
         Dbg->Reset();
         DebugUpdate();

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -144,6 +144,7 @@ void CSound::InitDevices()
 {
         AYInit();
         SpecDrumInit();
+        sp0256_AL2.Reset();
 }
 
 // Initialise the AY Sound chip

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -240,7 +240,6 @@ void zx81_initialise()
         tStatesCount = 0;
 
         insertWaitsWhileSP0256Busy = false;
-        sp0256_AL2.Reset();
 
         chromaSelected = (machine.colour == COLOURCHROMA);
         lambdaSelected = (emulator.machine == MACHINELAMBDA);


### PR DESCRIPTION
- Centralized sound resetting behavior and hard resets and initialization.
- Limited reset behavior on soft resets. The only sound device I found that is tied to the reset line is the Sinclair 128k sound. I know that ZON X does not. I do not have other device schematics to see if they actually detect the assertion of the reset line.