### PR TITLE
Added support for US keyboards

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -51,7 +51,7 @@ Version 1.41 - 27/01/2025 (by Paul Farrow and John Stroebel)
   - Added support for MIDI output to Spectrum 128 and Spectrum+2.
   - Default sound volume settings are in the middle of the range.
   - Added ability to cancel changes on the hardware configuration dialog.
-  - Added support for US keyboards.
+  - Default cursor keys are selected based on the chosen machine unless custom keys are defined.
 * Enhancements:
   - Separated and updated the documentation for CHR$128 mode and the ARX true high resolution
     display mechanism.
@@ -70,6 +70,8 @@ Version 1.41 - 27/01/2025 (by Paul Farrow and John Stroebel)
   - Added emulation of 3-Channel Sound Unit by dk'tronics Ltd for the ZX Spectrum.
   - Added emulation of the ZON X sound interface by Bi-Pak for the ZX Spectrum.
   - Added emulation of the SpecDrum by Cheetah Marketing Ltd for the ZX Spectrum.
+  - Added support for CAPS LOCK key and US keyboards on Spectrum 16k/48k/48k+, Amstrad +2/+2A/+3,
+    TS2068, TC2048, TC2068, and Jupiter Ace.
 
 Version 1.40 - 07/02/2024 (by Paul Farrow)
 * Bug fixes:

--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -51,6 +51,7 @@ Version 1.41 - 27/01/2025 (by Paul Farrow and John Stroebel)
   - Added support for MIDI output to Spectrum 128 and Spectrum+2.
   - Default sound volume settings are in the middle of the range.
   - Added ability to cancel changes on the hardware configuration dialog.
+  - Added support for US keyboards.
 * Enhancements:
   - Separated and updated the documentation for CHR$128 mode and the ARX true high resolution
     display mechanism.

--- a/Source/kbstatus.cpp
+++ b/Source/kbstatus.cpp
@@ -280,7 +280,7 @@ const struct kb KBACE[]=
 
         { 1, VK_OEM_1, kbA13, kbD1, kbA8, kbD1 },
         { 2, VK_OEM_1, kbA8, kbD2, kbA8, kbD1 },
-        //{ 1, VK_OEM_3, kbA13, kbD1, kbA8, kbD1 },
+        { 1, VK_OEM_3, kbA12, kbD3, kbA8, kbD1 },
         { 2, VK_OEM_3, kbA11, kbD1, kbA8, kbD1 },
         { 1, VK_OEM_7, kbA11, kbD2, kbA8, kbD1 },
         { 2, VK_OEM_7, kbA9, kbD0, kbA8, kbD1 },
@@ -308,6 +308,8 @@ const struct kb KBACE[]=
         { 0, VK_UP , kbA12, kbD4, kbA8, kbD0 },
         { 0, VK_DOWN , kbA12, kbD3, kbA8, kbD0 },
         { 0, VK_RIGHT , kbA12, kbD2, kbA8, kbD0 },
+
+        { 0, VK_CAPITAL , kbA11, kbD1, kbA8, kbD0 },
         {0, 0, 0, 0, 0, 0 }
 };
 
@@ -699,7 +701,7 @@ void AdjustLocalKeyboard()
                 case 0x00001404: // Chinese (Traditional, Macao S.A.R.) - US
                 case 0x00010402: // Bulgarian (Latin)
                 case 0x00020409: // United States-International
-                        if (emulator.machine==MACHINESPECTRUM)
+                        if (emulator.machine==MACHINESPECTRUM || emulator.machine==MACHINEACE)
                         {
                                 int source=PCFindKey(VK_OEM_3,false);
                                 int dest=PCFindKey(VK_OEM_7,false);
@@ -708,12 +710,14 @@ void AdjustLocalKeyboard()
 
                                 source=PCFindKey('P');
                                 dest=PCFindKey(VK_OEM_7,true);
+                                BYTE tempAddr1=KeyMap[dest].Addr1;
+                                BYTE tempData1=KeyMap[dest].Data1;
                                 KeyMap[dest].Addr1 = KeyMap[source].Addr1;
                                 KeyMap[dest].Data1 = KeyMap[source].Data1;
 
                                 dest=PCFindKey(VK_OEM_3,true);
-                                KeyMap[dest].Addr1 = 0;
-                                KeyMap[dest].Data1 = 0;
+                                KeyMap[dest].Addr1 = tempAddr1;
+                                KeyMap[dest].Data1 = tempData1;
                         }
                         break;
 

--- a/Source/kbstatus.cpp
+++ b/Source/kbstatus.cpp
@@ -701,8 +701,8 @@ void AdjustLocalKeyboard()
                 case 0x00020409: // United States-International
                         if (emulator.machine==MACHINESPECTRUM)
                         {
-                                int source=PCFindKey(VK_OEM_3);
-                                int dest=PCFindKey(VK_OEM_7);
+                                int source=PCFindKey(VK_OEM_3,false);
+                                int dest=PCFindKey(VK_OEM_7,false);
                                 KeyMap[dest].Addr1 = KeyMap[source].Addr1;
                                 KeyMap[dest].Data1 = KeyMap[source].Data1;
 

--- a/Source/kbstatus.cpp
+++ b/Source/kbstatus.cpp
@@ -557,7 +557,7 @@ int PCFindKey(Word key, int shift)
         {
                 if (KeyMap[i].WinKey == key)
                 {
-                        if ((KeyMap[i].Shift==2 && shift) || (KeyMap[i].Shift<2 && ! shift))
+                        if ((KeyMap[i].Shift==2 && shift) || (KeyMap[i].Shift<2 && !shift))
                                 return(i);
                 }
                 i++;

--- a/Source/kbstatus.cpp
+++ b/Source/kbstatus.cpp
@@ -549,7 +549,7 @@ void SetKeyMap(const kb *source)
         KeyMap[i]=source[i];
 }
 
-int PCFindKey(Word key, int shift)
+int PCFindKey(Word key, bool shift)
 {
         int i=0;
 
@@ -568,7 +568,7 @@ int PCFindKey(Word key, int shift)
 
 int PCFindKey(Word key)
 {
-        return PCFindKey(key,0);
+        return PCFindKey(key,false);
 }
 
 void PCSetKey(WORD dest, int source, int shift)
@@ -707,11 +707,11 @@ void AdjustLocalKeyboard()
                                 KeyMap[dest].Data1 = KeyMap[source].Data1;
 
                                 source=PCFindKey('P');
-                                dest=PCFindKey(VK_OEM_7,1);
+                                dest=PCFindKey(VK_OEM_7,true);
                                 KeyMap[dest].Addr1 = KeyMap[source].Addr1;
                                 KeyMap[dest].Data1 = KeyMap[source].Data1;
 
-                                dest=PCFindKey(VK_OEM_3,1);
+                                dest=PCFindKey(VK_OEM_3,true);
                                 KeyMap[dest].Addr1 = 0;
                                 KeyMap[dest].Data1 = 0;
                         }


### PR DESCRIPTION
- Keymapping will be modified if a US keyboard is detected and the machine is a Spectrum or Ace.
- The CAPS LOCK key will be detected by Spectrum and Ace machines. (Note that it is impossible to have the CAPS LOCK keyboard LED track what the Spectrum thinks is the state of the CAPS LOCK key, so we will rely on the inverse C indicator on the Spectrum screen.)
- Enabled the ~ key on the Ace.