### PR TITLE
Reverted Digitalker variables to proper signs based on original MAME data types to prevent stalls

### DIFF
--- a/Source/Digitalker/Digitalk.cpp
+++ b/Source/Digitalker/Digitalk.cpp
@@ -1,5 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:Olivier Galibert
+
+#pragma warn -8071
+
 #include "digitalk.h"
 
 /*
@@ -281,9 +284,9 @@ digitalker_device::digitalker_device()
 {
 }
 
-void digitalker_device::digitalker_write(int *adr, int vol, int dac)
+void digitalker_device::digitalker_write(uint8_t *adr, uint8_t vol, int8_t dac)
 {
-	int v;
+	int16_t v;
 	dac &= 15;
 	if(dac >= 9)
 		v = -pcm_levels[vol][15-dac];
@@ -294,7 +297,7 @@ void digitalker_device::digitalker_write(int *adr, int vol, int dac)
 	m_dac[(*adr)++] = v;
 }
 
-int digitalker_device::digitalker_pitch_next(int val, int prev, int step)
+uint8_t digitalker_device::digitalker_pitch_next(uint8_t val, uint8_t prev, int step)
 {
 	int delta, nv;
 
@@ -312,12 +315,12 @@ int digitalker_device::digitalker_pitch_next(int val, int prev, int step)
 	return nv;
 }
 
-void digitalker_device::digitalker_set_intr(int intr)
+void digitalker_device::digitalker_set_intr(uint8_t intr)
 {
 	m_intr = intr;
 }
 
-void digitalker_device::digitalker_start_command(int cmd)
+void digitalker_device::digitalker_start_command(uint8_t cmd)
 {
 	m_bpos = ((m_rom[cmd*2] << 8) | m_rom[cmd*2+1]) & 0x3fff;
 	m_cur_segment = m_segments = m_cur_repeat = m_repeats = 0;
@@ -328,13 +331,13 @@ void digitalker_device::digitalker_start_command(int cmd)
 
 void digitalker_device::digitalker_step_mode_0()
 {
-	int dac = 0;
+	int8_t dac = 0;
 	int i, k, l;
-	int wpos = 0;
-	int h = m_rom[m_apos];
-	int bits = 0x80;
-	int vol = h >> 5;
-	int pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
+	uint8_t wpos = 0;
+	uint8_t h = m_rom[m_apos];
+	uint16_t bits = 0x80;
+	uint8_t vol = h >> 5;
+	uint8_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
 
 	m_pitch = pitch_vals[pitch_id];
 
@@ -381,13 +384,13 @@ void digitalker_device::digitalker_step_mode_1()
 
 void digitalker_device::digitalker_step_mode_2()
 {
-	int dac = 0;
+	int8_t dac = 0;
 	int k, l;
-	int wpos=0;
-	int h = m_rom[m_apos];
-	int bits = 0x80;
-	int vol = h >> 5;
-	int pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
+	uint8_t wpos=0;
+	uint8_t h = m_rom[m_apos];
+	uint16_t bits = 0x80;
+	uint8_t vol = h >> 5;
+	uint8_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
 
 	m_pitch = pitch_vals[pitch_id];
 
@@ -445,10 +448,10 @@ void digitalker_device::digitalker_step_mode_2()
 
 void digitalker_device::digitalker_step_mode_3()
 {
-	int h = m_rom[m_apos];
-	int vol = h >> 5;
-	int bits;
-	int dac, apos, wpos;
+	uint8_t h = m_rom[m_apos];
+	uint8_t vol = h >> 5;
+	uint16_t bits;
+	uint8_t dac, apos, wpos;
 	int k, l;
 
 	m_pitch = pitch_vals[h & 0x1f];
@@ -486,9 +489,9 @@ void digitalker_device::digitalker_step()
 		if(m_stop_after == 0 && m_bpos == 0xffff)
 			return;
 		if(m_stop_after == 0) {
-			int v1 = m_rom[m_bpos++];
-			int v2 = m_rom[m_bpos++];
-			int v3 = m_rom[m_bpos++];
+			uint8_t v1 = m_rom[m_bpos++];
+			uint8_t v2 = m_rom[m_bpos++];
+			uint8_t v3 = m_rom[m_bpos++];
 			m_apos = v2 | ((v3 << 8) & 0x3f00);
 			m_segments = (v1 & 15) + 1;
 			m_repeats = ((v1 >> 4) & 7) + 1;

--- a/Source/Digitalker/Digitalk.cpp
+++ b/Source/Digitalker/Digitalk.cpp
@@ -284,7 +284,7 @@ digitalker_device::digitalker_device()
 {
 }
 
-void digitalker_device::digitalker_write(uint8_t *adr, uint8_t vol, int8_t dac)
+void digitalker_device::digitalker_write(uint16_t *adr, uint16_t vol, int8_t dac)
 {
 	int16_t v;
 	dac &= 15;
@@ -297,7 +297,7 @@ void digitalker_device::digitalker_write(uint8_t *adr, uint8_t vol, int8_t dac)
 	m_dac[(*adr)++] = v;
 }
 
-uint8_t digitalker_device::digitalker_pitch_next(uint8_t val, uint8_t prev, int step)
+uint8_t digitalker_device::digitalker_pitch_next(uint16_t val, uint16_t prev, int step)
 {
 	int delta, nv;
 
@@ -333,11 +333,11 @@ void digitalker_device::digitalker_step_mode_0()
 {
 	int8_t dac = 0;
 	int i, k, l;
-	uint8_t wpos = 0;
+	uint16_t wpos = 0;
 	uint8_t h = m_rom[m_apos];
 	uint16_t bits = 0x80;
-	uint8_t vol = h >> 5;
-	uint8_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
+	uint16_t vol = h >> 5;
+	uint16_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
 
 	m_pitch = pitch_vals[pitch_id];
 
@@ -384,13 +384,13 @@ void digitalker_device::digitalker_step_mode_1()
 
 void digitalker_device::digitalker_step_mode_2()
 {
-	int8_t dac = 0;
+	int16_t dac = 0;
 	int k, l;
-	uint8_t wpos=0;
+	uint16_t wpos=0;
 	uint8_t h = m_rom[m_apos];
 	uint16_t bits = 0x80;
-	uint8_t vol = h >> 5;
-	uint8_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
+	uint16_t vol = h >> 5;
+	uint16_t pitch_id = m_cur_segment ? digitalker_pitch_next(h, m_prev_pitch, m_cur_repeat) : h & 0x1f;
 
 	m_pitch = pitch_vals[pitch_id];
 
@@ -449,9 +449,9 @@ void digitalker_device::digitalker_step_mode_2()
 void digitalker_device::digitalker_step_mode_3()
 {
 	uint8_t h = m_rom[m_apos];
-	uint8_t vol = h >> 5;
+	uint16_t vol = h >> 5;
 	uint16_t bits;
-	uint8_t dac, apos, wpos;
+	uint16_t dac, apos, wpos;
 	int k, l;
 
 	m_pitch = pitch_vals[h & 0x1f];

--- a/Source/Digitalker/Digitalk.h
+++ b/Source/Digitalker/Digitalk.h
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <cstring>
+#include "types.h"
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -19,18 +20,18 @@ class digitalker_device
 public:
 	digitalker_device();
 
-	void digitalker_start_command(int cmd);
+	void digitalker_start_command(uint8_t cmd);
 	int digitalker_0_intr_r();
         int single_sample(void);
-        void setROM(unsigned char *romPtr);
+        void setROM(uint8_t *romPtr);
 
 	// device-level overrides
 	void device_start();
 
 private:
-	void digitalker_write(int *adr, int vol, int dac);
-	int digitalker_pitch_next(int val, int prev, int step);
-	void digitalker_set_intr(int intr);
+	void digitalker_write(uint8_t *adr, uint8_t vol, int8_t dac);
+	uint8_t digitalker_pitch_next(uint8_t val, uint8_t prev, int step);
+	void digitalker_set_intr(uint8_t intr);
 	void digitalker_step_mode_0();
 	void digitalker_step_mode_1();
 	void digitalker_step_mode_2();
@@ -39,35 +40,35 @@ private:
 	int digitalker_intr_r();
 
 	// Port/lines state
-	int m_data;
-	int m_intr;
+	uint8_t m_data;
+	uint8_t m_intr;
 
 	// Current decoding state
-	int m_bpos;
-	int m_apos;
+	uint16_t m_bpos;
+	uint16_t m_apos;
 
-	int m_mode;
-	int m_cur_segment;
-	int m_cur_repeat;
-	int m_segments;
-	int m_repeats;
+	uint8_t m_mode;
+	uint8_t m_cur_segment;
+	uint8_t m_cur_repeat;
+	uint8_t m_segments;
+	uint8_t m_repeats;
 
-	int m_prev_pitch;
-	int m_pitch;
-	int m_pitch_pos;
+	uint8_t m_prev_pitch;
+	uint8_t m_pitch;
+	uint8_t m_pitch_pos;
 
-	int m_stop_after;
-	int m_cur_dac;
-	int m_cur_bits;
+	uint8_t m_stop_after;
+	uint8_t m_cur_dac;
+	uint8_t m_cur_bits;
 
 	// Zero-range size
-	unsigned int m_zero_count; // 0 for done
+	uint32_t m_zero_count; // 0 for done
 
 	// Waveform and current index in it
-	int m_dac_index; // 128 for done
-	int m_dac[128];
+	uint8_t m_dac_index; // 128 for done
+	int16_t m_dac[128];
 
-        unsigned char *m_rom;
+        uint8_t *m_rom;
 };
 
 #endif // MAME_SOUND_DIGITALK_H

--- a/Source/Digitalker/Digitalk.h
+++ b/Source/Digitalker/Digitalk.h
@@ -29,8 +29,8 @@ public:
 	void device_start();
 
 private:
-	void digitalker_write(uint8_t *adr, uint8_t vol, int8_t dac);
-	uint8_t digitalker_pitch_next(uint8_t val, uint8_t prev, int step);
+	void digitalker_write(uint16_t *adr, uint16_t vol, int8_t dac);
+	uint8_t digitalker_pitch_next(uint16_t val, uint16_t prev, int step);
 	void digitalker_set_intr(uint8_t intr);
 	void digitalker_step_mode_0();
 	void digitalker_step_mode_1();
@@ -53,13 +53,13 @@ private:
 	uint8_t m_segments;
 	uint8_t m_repeats;
 
-	uint8_t m_prev_pitch;
-	uint8_t m_pitch;
-	uint8_t m_pitch_pos;
+	uint16_t m_prev_pitch;
+	uint16_t m_pitch;
+	uint16_t m_pitch_pos;
 
 	uint8_t m_stop_after;
-	uint8_t m_cur_dac;
-	uint8_t m_cur_bits;
+	uint16_t m_cur_dac;
+	uint16_t m_cur_bits;
 
 	// Zero-range size
 	uint32_t m_zero_count; // 0 for done

--- a/Source/Digitalker/Digitalkdrv.cpp
+++ b/Source/Digitalker/Digitalkdrv.cpp
@@ -23,7 +23,7 @@ void Digitalk::Init(const char* romBasePath)
         FILE* f = fopen(romFilePath, "rb");
         if (f)
         {
-                fread((unsigned char*)rombank1, 1, 0x2000, f);
+                fread(rombank1, 1, 0x2000, f);
                 fclose(f);
         }
 
@@ -32,7 +32,7 @@ void Digitalk::Init(const char* romBasePath)
         f = fopen(romFilePath, "rb");
         if (f)
         {
-                fread((unsigned char*)&rombank1[0x2000], 1, 0x2000, f);
+                fread(&rombank1[0x2000], 1, 0x2000, f);
                 fclose(f);
         }
 
@@ -41,7 +41,7 @@ void Digitalk::Init(const char* romBasePath)
         f = fopen(romFilePath, "rb");
         if (f)
         {
-                fread((unsigned char*)rombank2, 1, 0x2000, f);
+                fread(rombank2, 1, 0x2000, f);
                 fclose(f);
         }
 
@@ -50,7 +50,7 @@ void Digitalk::Init(const char* romBasePath)
         f = fopen(romFilePath, "rb");
         if (f)
         {
-                fread((unsigned char*)&rombank2[0x2000], 1, 0x2000, f);
+                fread(&rombank2[0x2000], 1, 0x2000, f);
                 fclose(f);
         }
 }


### PR DESCRIPTION
The Digitalker emulation depends on unsigned data types for many of its calculations. I had changed data types thinking it was causing some issues getting the code running. These changes introduced the possibility of the emulation to stall.
This PR reverts to the original signed/unsigned types and I no longer see stalls. I also made some variables wider than the originals to improve sound quality.