### PR TITLE
Hardware configuration window is no longer modal

### DIFF
--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -457,7 +457,7 @@ void __fastcall TForm1::UserDefined1Click(TObject *Sender)
 void __fastcall TForm1::Display1Click(TObject *Sender)
 {
         PCAllKeysUp();
-        HW->ShowModal();
+        HW->Show();
 }
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
I don't see a need to force this window to block out everything else now that we can cancel out of it. It might be handy for users to be able to stay aware of the current configuration.