### PR TITLE
Updated ZX97 Configuration form to behave like HW form

### DIFF
--- a/Source/FullScreen.dfm
+++ b/Source/FullScreen.dfm
@@ -94,7 +94,9 @@ object FSSettings: TFSSettings
     Width = 65
     Height = 17
     Caption = 'GDI'
+    Checked = True
     TabOrder = 0
+    TabStop = True
     OnClick = GDIBtnClick
   end
   object DDrawBtn: TRadioButton
@@ -103,9 +105,7 @@ object FSSettings: TFSSettings
     Width = 89
     Height = 17
     Caption = 'DirectDraw'
-    Checked = True
     TabOrder = 1
-    TabStop = True
     OnClick = GDIBtnClick
   end
 end

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -114,6 +114,7 @@ __fastcall THW::THW(TComponent* Owner)
         ZXCFRAM->ItemIndex = FindEntry(ZXCFRAM, "1024K");
         ZX81BtnClick(NULL);
 
+        SaveToInternalSettings(); // save in case there is no INI file
         TIniFile* ini = new TIniFile(emulator.inipath);
         LoadSettings(ini);
         delete ini;

--- a/Source/HW_.dfm
+++ b/Source/HW_.dfm
@@ -14,7 +14,6 @@ object HW: THW
   Font.Style = []
   OldCreateOrder = False
   Scaled = False
-  OnClose = FormClose
   OnCreate = FormCreate
   OnShow = FormShow
   PixelsPerInch = 96

--- a/Source/HW_.h
+++ b/Source/HW_.h
@@ -29,14 +29,9 @@ using namespace std;
 #include <ImgList.hpp>
 #include <Graphics.hpp>
 #include "Joystick.h"
+#include "Utils.h"
 
 //---------------------------------------------------------------------------
-
-enum IniFileAccessType
-{
-        Read,
-        Write
-};
 
 struct RomCartridgeEntry
 {
@@ -259,7 +254,6 @@ __published:	// IDE-managed Components
         void __fastcall TC2068RomCartridgeFileBoxChange(TObject *Sender);
         void __fastcall ZXpandEmulationInfoClick(TObject *Sender);
         void __fastcall SpeechBoxChange(TObject *Sender);
-        void __fastcall FormClose(TObject *Sender, TCloseAction &Action);
         void __fastcall CancelClick(TObject *Sender);
         void __fastcall JoystickBoxChange(TObject *Sender);
         void __fastcall JoystickBoxMouseUp(TObject *Sender,
@@ -303,10 +297,6 @@ private:	// User declarations
         void UpdateJoystickOptions();
         void WriteNVMemory(BYTE* memory, int size, int count, char* fileName);
         void ReadNVMemory(BYTE* memory, int size, int count, char* fileName);
-        void AccessIniFileBoolean(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, bool& entryValue);
-        void AccessIniFileInteger(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, int& entryValue);
-        void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, AnsiString& entryValue);
-        void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, char* entryValue);
         void AccessIniFile(TIniFile* ini, IniFileAccessType accessType);
         bool NewKey(TEdit* textBox, char key);
         void LoadRomBox();

--- a/Source/Plus3Drives.cpp
+++ b/Source/Plus3Drives.cpp
@@ -916,40 +916,49 @@ bool TP3Drive::CreateMicrodriveCartridge(AnsiString& filePath)
                 if (SaveDialogNewFloppyDisk->Execute())
                 {
                         filePath = SaveDialogNewFloppyDisk->FileName;
+
+                        if (!access(filePath.c_str(), F_OK))
+                        {
+                                ShowMessage("File already exists.");
+                                success = false;
+                        }
                 }
         }
 
         if (!filePath.IsEmpty())
         {
-                FILE* f = fopen(filePath.c_str(), "wb");
-                if (f)
+                if (access(filePath.c_str(),F_OK))
                 {
-                        try
+                        FILE* f = fopen(filePath.c_str(), "wb");
+                        if (f)
                         {
-                                const int sizeOfMicrodriveFile = (254 * 543) + 1;
-
-                                for (int i = 0; i < sizeOfMicrodriveFile - 1; i++)
+                                try
                                 {
-                                        // 'Blank' data
-                        	        fputc(0xFC, f);
+                                        const int sizeOfMicrodriveFile = (254 * 543) + 1;
+
+                                        for (int i = 0; i < sizeOfMicrodriveFile - 1; i++)
+                                        {
+                                                // 'Blank' data
+                                	        fputc(0xFC, f);
+                                        }
+
+                                        // The cartridge is not write protected (this byte is not used by EightyOne)
+                                        fputc(0x00, f);
+                                }
+                                catch (...)
+                                {
+                                        success = false;
                                 }
 
-                                // The cartridge is not write protected (this byte is not used by EightyOne)
-                                fputc(0x00, f);
+                                if (fclose(f))
+                                {
+                                        success = false;
+                                }
                         }
-                        catch (...)
+                        else
                         {
                                 success = false;
                         }
-
-                        if (fclose(f))
-                        {
-                                success = false;
-                        }
-                }
-                else
-                {
-                        success = false;
                 }
 
                 if (!success)

--- a/Source/Plus3Drives.cpp
+++ b/Source/Plus3Drives.cpp
@@ -925,7 +925,7 @@ bool TP3Drive::CreateMicrodriveCartridge(AnsiString& filePath)
                 }
         }
 
-        if (!filePath.IsEmpty())
+        if (success && !filePath.IsEmpty())
         {
                 if (access(filePath.c_str(),F_OK))
                 {

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -366,3 +366,52 @@ int EnumeratePorts(TStrings *List, AnsiString Type)
 
 //---------------------------------------------------------------------------
 
+void AccessIniFileInteger(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, int& entryValue)
+{
+        if (accessType == Write)
+        {
+                ini->WriteInteger(section, entryName, entryValue);
+        }
+        else
+        {
+                entryValue = ini->ReadInteger(section, entryName, entryValue);
+        }
+}
+
+void AccessIniFileBoolean(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, bool& entryValue)
+{
+        if (accessType == Write)
+        {
+                ini->WriteBool(section, entryName, entryValue);
+        }
+        else
+        {
+                entryValue = ini->ReadBool(section, entryName, entryValue);
+        }
+}
+
+void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, AnsiString& entryValue)
+{
+        if (accessType == Write)
+        {
+                ini->WriteString(section, entryName, entryValue);
+        }
+        else
+        {
+                entryValue = ini->ReadString(section, entryName, entryValue);
+        }
+}
+
+void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, char* entryValue)
+{
+        if (accessType == Write)
+        {
+                ini->WriteString(section, entryName, entryValue);
+        }
+        else
+        {
+                AnsiString value = ini->ReadString(section, entryName, entryValue);
+                strcpy(entryValue, value.c_str());
+        }
+}
+

--- a/Source/Utils.h
+++ b/Source/Utils.h
@@ -25,7 +25,15 @@
 #define UtilsH
 //---------------------------------------------------------------------------
 
+#include <IniFiles.hpp>
 #include "zx81config.h"
+
+enum IniFileAccessType
+{
+        Read,
+        Write
+};
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,6 +56,10 @@ AnsiString RemoveExt(AnsiString Fname);
 AnsiString GetExt(AnsiString Fname);
 AnsiString RemovePath(AnsiString Str);
 int EnumeratePorts(TStrings *List, AnsiString Type);
+void AccessIniFileBoolean(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, bool& entryValue);
+void AccessIniFileInteger(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, int& entryValue);
+void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, AnsiString& entryValue);
+void AccessIniFileString(TIniFile* ini, IniFileAccessType accessType, AnsiString section, AnsiString entryName, char* entryValue);
 
 #endif
 

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -1290,6 +1290,7 @@ void TForm1::SaveSettings(TIniFile *ini)
         FSSettings->SaveSettings(ini);
         P3Drive->SaveSettings(ini);
         SoundOutput->SaveSettings(ini);
+        ZX97Dialog->SaveSettings(ini);
         IF1->SaveSettings(ini);
         ParallelPort->SaveSettings(ini);
         MidiForm->SaveSettings(ini);

--- a/Source/zx97Config.cpp
+++ b/Source/zx97Config.cpp
@@ -33,91 +33,32 @@
 #pragma resource "*.dfm"
 TZX97Dialog *ZX97Dialog;
 
-extern "C" void z80_reset();
-
 //---------------------------------------------------------------------------
 __fastcall TZX97Dialog::TZX97Dialog(TComponent* Owner)
         : TForm(Owner)
 {
-        FILE *f;
-        char filename[256];
         TIniFile *ini;
 
         ini = new TIniFile(emulator.inipath);
         LoadSettings(ini);
         delete ini;
+}
+//---------------------------------------------------------------------------
+void TZX97Dialog::UpdateRequired(void)
+{
+        SaveToInternalSettings(); // save copy to keep user choices
+        zx97.saveram=Zx97form.saveram;
+        zx97.protectab=Zx97form.protectab;
+        zx97.protect08=Zx97form.protect08;
+        zx97.protectb0=Zx97form.protectb0;
+        zx97.protectb115=Zx97form.protectb115;
+        zx97.bankswitch=Zx97form.bankswitch;
+}
 
-        strcpy(filename, emulator.cwd);
-        strcat(filename, nvMemoryFolder);
-        strcat(filename, "zx97.nv");
-
-        f=fopen(filename,"rb");
-        if (f)
-        {
-                fread(zx97.bankmem, 16384, 16, f);
-                fclose(f);
-        }
-
-        PrinterOutput->ItemIndex=0;
-
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::PrinterOutputChange(TObject *Sender)
-{
-        if (PrinterOutput->ItemIndex==0)
-        {
-                Label3->Visible=true;
-                FileName->Visible=true;
-                FileNameSelector->Visible=true;
-        }
-        else
-        {
-                Label3->Visible=false;
-                FileName->Visible=false;
-                FileNameSelector->Visible=false;
-        }
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::FileNameSelectorClick(TObject *Sender)
-{
-        if(SaveDialog1->Execute()) FileName->Text=SaveDialog1->FileName;
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::Protect08Click(TObject *Sender)
-{
-        zx97.protect08=Protect08->Checked;
-
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::ProtectABClick(TObject *Sender)
-{
-        zx97.protectab=ProtectAB->Checked;
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::ProtectB0Click(TObject *Sender)
-{
-        zx97.protectb0=ProtectB0->Checked;
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::ProtectB115Click(TObject *Sender)
-{
-        zx97.protectb115=ProtectB115->Checked;
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::OKClick(TObject *Sender)
-{
-        Close();
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::FormDestroy(TObject *Sender)
+void TZX97Dialog::SaveSettings(TIniFile *ini)
 {
         FILE *f;
         char filename[256];
-        TIniFile *ini;
-
-        ini = new TIniFile(emulator.inipath);
-        SaveSettings(ini);
-        delete ini;
 
         if (SaveRAM->Checked)
         {
@@ -128,44 +69,78 @@ void __fastcall TZX97Dialog::FormDestroy(TObject *Sender)
                 f=fopen(filename,"wb");
                 if (f)
                 {
-                        fwrite(zx97.bankmem, 16384, 16, f);
+                        fwrite(Zx97form.bankmem, 16384, 16, f);
                         fclose(f);
                 }
         }
-}
-//---------------------------------------------------------------------------
-void __fastcall TZX97Dialog::SwapRAMROMClick(TObject *Sender)
-{
-        zx97.bankswitch=(SwapRAMROM->Checked!=0);
-        z80_reset();
-}
-//---------------------------------------------------------------------------
-void TZX97Dialog::SaveSettings(TIniFile *ini)
-{
-        ini->WriteInteger("ZX97","Top",Top);
-        ini->WriteInteger("ZX97","Left",Left);
-        //ini->WriteInteger("ZX97","Height",Height);
-        //ini->WriteInteger("ZX97","Width",Width);
 
-        ini->WriteBool("ZX97","08k", Protect08->Checked);
-        ini->WriteBool("ZX97","abk", ProtectAB->Checked);
-        ini->WriteBool("ZX97","b0", ProtectB0->Checked);
-        ini->WriteBool("ZX97","b115", ProtectB115->Checked);
-        ini->WriteBool("ZX97","SaveRAM", SaveRAM->Checked);
+        AccessIniFile(ini, Write);
 }
 
 void TZX97Dialog::LoadSettings(TIniFile *ini)
 {
-        Top=ini->ReadInteger("ZX97","Top",Top);
-        Left=ini->ReadInteger("ZX97","Left",Left);
-        //Height=ini->ReadInteger("ZX97","Height",Height);
-        //Width=ini->ReadInteger("ZX97","Width",Width);
+        FILE *f;
+        char filename[256];
 
-        Protect08->Checked=ini->ReadBool("ZX97","08k", Protect08->Checked);
-        ProtectAB->Checked=ini->ReadBool("ZX97","abk", ProtectAB->Checked);
-        ProtectB0->Checked=ini->ReadBool("ZX97","b0", ProtectB0->Checked);
-        ProtectB115->Checked=ini->ReadBool("ZX97","b115", ProtectB115->Checked);
-        SaveRAM->Checked=ini->ReadBool("ZX97","SaveRAM", SaveRAM->Checked);
+        strcpy(filename, emulator.cwd);
+        strcat(filename, nvMemoryFolder);
+        strcat(filename, "zx97.nv");
+
+        f=fopen(filename,"rb");
+        if (f)
+        {
+                fread(Zx97form.bankmem, 16384, 16, f);
+                fclose(f);
+        }
+
+        AccessIniFile(ini, Read);
+        LoadFromInternalSettings(); // restore form settings from copy
+}
+
+void TZX97Dialog::AccessIniFile(TIniFile* ini, IniFileAccessType accessType)
+{
+        AccessIniFileInteger(ini, accessType, "ZX97", "Top",   Top);
+        AccessIniFileInteger(ini, accessType, "ZX97", "Left",  Left);
+
+        AccessIniFileInteger(ini, accessType, "ZX97", "SaveRAM",    Zx97form.saveram);
+        AccessIniFileInteger(ini, accessType, "ZX97", "08k",        Zx97form.protect08);
+        AccessIniFileInteger(ini, accessType, "ZX97", "abk",        Zx97form.protectab);
+        AccessIniFileInteger(ini, accessType, "ZX97", "b0",         Zx97form.protectb0);
+        AccessIniFileInteger(ini, accessType, "ZX97", "b115",       Zx97form.protectb115);
+        AccessIniFileInteger(ini, accessType, "ZX97", "SwapRAMROM", Zx97form.bankswitch);
+}
+
+//---------------------------------------------------------------------------
+
+void TZX97Dialog::SaveToInternalSettings()
+{
+        Zx97form.saveram=SaveRAM->Checked;
+        Zx97form.protectab=ProtectAB->Checked;
+        Zx97form.protect08=Protect08->Checked;
+        Zx97form.protectb0=ProtectB0->Checked;
+        Zx97form.protectb115=ProtectB115->Checked;
+        Zx97form.bankswitch=(SwapRAMROM->Checked!=0);
+}
+
+void TZX97Dialog::LoadFromInternalSettings()
+{
+        SaveRAM->Checked=Zx97form.saveram;
+        ProtectAB->Checked=Zx97form.protectab;
+        Protect08->Checked=Zx97form.protect08;
+        ProtectB0->Checked=Zx97form.protectb0;
+        ProtectB115->Checked=Zx97form.protectb115;
+        SwapRAMROM->Checked=Zx97form.bankswitch;
+}
+
+void __fastcall TZX97Dialog::FormShow(TObject *Sender)
+{
+        LoadFromInternalSettings();  // restore form settings from copy
+}
+//---------------------------------------------------------------------------
+
+void __fastcall TZX97Dialog::CancelClick(TObject *Sender)
+{
+        LoadFromInternalSettings(); // restore form settings from copy
 }
 //---------------------------------------------------------------------------
 

--- a/Source/zx97Config.cpp
+++ b/Source/zx97Config.cpp
@@ -39,6 +39,7 @@ __fastcall TZX97Dialog::TZX97Dialog(TComponent* Owner)
 {
         TIniFile *ini;
 
+        SaveToInternalSettings(); // save in case there is no INI file
         ini = new TIniFile(emulator.inipath);
         LoadSettings(ini);
         delete ini;

--- a/Source/zx97Config.dfm
+++ b/Source/zx97Config.dfm
@@ -14,7 +14,7 @@ object ZX97Dialog: TZX97Dialog
   Font.Style = []
   OldCreateOrder = False
   Scaled = False
-  OnDestroy = FormDestroy
+  OnShow = FormShow
   PixelsPerInch = 96
   TextHeight = 13
   object Label1: TLabel
@@ -23,20 +23,6 @@ object ZX97Dialog: TZX97Dialog
     Width = 37
     Height = 13
     Caption = 'Protect:'
-  end
-  object Label2: TLabel
-    Left = 176
-    Top = 36
-    Width = 66
-    Height = 13
-    Caption = 'Printer port to:'
-  end
-  object Label3: TLabel
-    Left = 176
-    Top = 58
-    Width = 45
-    Height = 13
-    Caption = 'Filename:'
   end
   object Protect08: TCheckBox
     Left = 56
@@ -47,7 +33,6 @@ object ZX97Dialog: TZX97Dialog
     Checked = True
     State = cbChecked
     TabOrder = 0
-    OnClick = Protect08Click
   end
   object ProtectAB: TCheckBox
     Left = 56
@@ -56,7 +41,6 @@ object ZX97Dialog: TZX97Dialog
     Height = 17
     Caption = '$A000 - $BFFF'
     TabOrder = 1
-    OnClick = ProtectABClick
   end
   object ProtectB0: TCheckBox
     Left = 56
@@ -67,7 +51,6 @@ object ZX97Dialog: TZX97Dialog
     Checked = True
     State = cbChecked
     TabOrder = 2
-    OnClick = ProtectB0Click
   end
   object ProtectB115: TCheckBox
     Left = 56
@@ -76,7 +59,6 @@ object ZX97Dialog: TZX97Dialog
     Height = 17
     Caption = 'Bank 1-15 (RAM)'
     TabOrder = 3
-    OnClick = ProtectB115Click
   end
   object SaveRAM: TCheckBox
     Left = 176
@@ -89,72 +71,34 @@ object ZX97Dialog: TZX97Dialog
     Checked = True
     ParentBiDiMode = False
     State = cbChecked
-    TabOrder = 5
-  end
-  object PrinterOutput: TComboBox
-    Left = 256
-    Top = 32
-    Width = 73
-    Height = 21
-    Style = csDropDownList
-    DropDownCount = 12
-    Enabled = False
-    ItemHeight = 13
-    TabOrder = 6
-    OnChange = PrinterOutputChange
-    Items.Strings = (
-      'File...'
-      'LPT1:'
-      'LPT2:'
-      'LPT3:'
-      'LPT4:'
-      'COM1:'
-      'COM2:'
-      'COM3:'
-      'COM4:'
-      'COM5:'
-      'COM6:'
-      'COM7:'
-      'COM8:')
-  end
-  object FileName: TEdit
-    Left = 224
-    Top = 56
-    Width = 81
-    Height = 21
-    Enabled = False
-    TabOrder = 7
-  end
-  object FileNameSelector: TButton
-    Left = 304
-    Top = 56
-    Width = 25
-    Height = 21
-    Caption = '...'
-    Enabled = False
-    TabOrder = 8
-    OnClick = FileNameSelectorClick
+    TabOrder = 4
   end
   object OK: TButton
-    Left = 256
+    Left = 173
     Top = 88
     Width = 75
     Height = 25
     Caption = 'OK'
-    TabOrder = 9
-    OnClick = OKClick
+    ModalResult = 1
+    TabOrder = 6
   end
   object SwapRAMROM: TCheckBox
-    Left = 56
-    Top = 88
+    Left = 216
+    Top = 24
     Width = 113
     Height = 17
+    Alignment = taLeftJustify
     Caption = 'Swap ROM/RAM'
-    TabOrder = 4
-    OnClick = SwapRAMROMClick
+    TabOrder = 5
   end
-  object SaveDialog1: TSaveDialog
-    Left = 8
-    Top = 24
+  object Cancel: TButton
+    Left = 253
+    Top = 88
+    Width = 75
+    Height = 25
+    Caption = 'Cancel'
+    ModalResult = 2
+    TabOrder = 7
+    OnClick = CancelClick
   end
 end

--- a/Source/zx97Config.h
+++ b/Source/zx97Config.h
@@ -30,6 +30,8 @@
 #include <Forms.hpp>
 #include <Dialogs.hpp>
 #include <IniFiles.hpp>
+#include "zx81config.h"
+#include "Utils.h"
 //---------------------------------------------------------------------------
 class TZX97Dialog : public TForm
 {
@@ -40,27 +42,20 @@ __published:	// IDE-managed Components
         TCheckBox *ProtectB0;
         TCheckBox *ProtectB115;
         TCheckBox *SaveRAM;
-        TLabel *Label2;
-        TComboBox *PrinterOutput;
-        TLabel *Label3;
-        TEdit *FileName;
-        TButton *FileNameSelector;
-        TSaveDialog *SaveDialog1;
         TButton *OK;
         TCheckBox *SwapRAMROM;
-        void __fastcall PrinterOutputChange(TObject *Sender);
-        void __fastcall FileNameSelectorClick(TObject *Sender);
-        void __fastcall Protect08Click(TObject *Sender);
-        void __fastcall ProtectABClick(TObject *Sender);
-        void __fastcall ProtectB0Click(TObject *Sender);
-        void __fastcall ProtectB115Click(TObject *Sender);
-        void __fastcall OKClick(TObject *Sender);
-        void __fastcall FormDestroy(TObject *Sender);
-        void __fastcall SwapRAMROMClick(TObject *Sender);
+        TButton *Cancel;
+        void __fastcall FormShow(TObject *Sender);
+        void __fastcall CancelClick(TObject *Sender);
 private:	// User declarations
-        void SaveSettings(TIniFile *ini);
+        void SaveToInternalSettings();
+        void LoadFromInternalSettings();
+        void AccessIniFile(TIniFile* ini, IniFileAccessType accessType);
+        ZX97 Zx97form;
 public:		// User declarations
         void LoadSettings(TIniFile *ini);
+        void SaveSettings(TIniFile *ini);
+        void UpdateRequired(void);
         __fastcall TZX97Dialog(TComponent* Owner);
 };
 //---------------------------------------------------------------------------


### PR DESCRIPTION
The ZX97 Configuration form had many issues and didn't conform to the new HW form operation. The result is that changing settings on the form caused immediate changes to emulation parameters. The updated form matches the pattern used by HW and integrates with the HW form such that changes will only be applied when the user clicks OK on both forms.
I also removed the permanently disabled and unused printed settings from this form.
Fixed an issue that caused opening of Microdrives to erase the file. Also preventing creation of a new Microdrive image file if one is already present (similar to the way floppies work).
Finally, I fixed the default selection on the Display mode form.