### PR TITLE
Fixed saving and loading of drive information

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -353,14 +353,6 @@ void THW::LoadFromInternalSettings()
         FloatingPointHardwareFix->Checked      = Hwform.FloatingPointHardwareFixChecked;
         uSource->Checked                       = Hwform.uSourceChecked;
 
-        if (Hwform.HD0 != "NULL") ATA_LoadHDF(0, Hwform.HD1.c_str());
-        if (Hwform.HD1 != "NULL") ATA_LoadHDF(1, Hwform.HD1.c_str());
-
-        for (int i = 0; i < 8; i++)
-        {
-                if (Hwform.MDV[i] != "NULL") IF1->MDVSetFileName(i, Hwform.MDV[i].c_str());
-        }
-
         //---- APPLY THE SETTINGS ----
 
         JoystickBoxChange(JoystickBox);
@@ -460,14 +452,6 @@ void THW::SaveToInternalSettings()
         Hwform.ZXCFUploadJumperOpenedChecked   = Form1->ZXCFUploadJumperOpened->Checked;
         Hwform.FloatingPointHardwareFixChecked = FloatingPointHardwareFix->Checked;
         Hwform.uSourceChecked                  = uSource->Checked;
-
-        Hwform.HD0                             = ATA_GetHDF(0) ? ATA_GetHDF(0) : "NULL";
-        Hwform.HD1                             = ATA_GetHDF(1) ? ATA_GetHDF(1) : "NULL";
-        
-        for (int i = 0; i < 8; i++)
-        {
-                Hwform.MDV[i] = IF1->MDVGetFileName(i) ? IF1->MDVGetFileName(i) : "NULL";
-        }
 }
 
 void THW::Configure8K16KRam()
@@ -3480,22 +3464,11 @@ void THW::AccessIniFile(TIniFile* ini, IniFileAccessType accessType)
         AccessIniFileString(ini, accessType, "HARDWARE", "DriveBType", Hwform.DriveBTypeText);
         AccessIniFileString(ini, accessType, "HARDWARE", "IDEType",    Hwform.IDEBoxText);
         AccessIniFileString(ini, accessType, "HARDWARE", "ZXCFRAM",    Hwform.ZXCFRAMText);
-        AccessIniFileString(ini, accessType, "HARDWARE", "DriveA",     Hwform.DriveA);
-        AccessIniFileString(ini, accessType, "HARDWARE", "DriveB",     Hwform.DriveB);
-        AccessIniFileString(ini, accessType, "HARDWARE", "HD0",        Hwform.HD0);
-        AccessIniFileString(ini, accessType, "HARDWARE", "HD1",        Hwform.HD1);
 
         AccessIniFileString(ini, accessType, "HARDWARE", "ROMSIMPLE3E",    emulator.ROMSIMPLE3E);
         AccessIniFileString(ini, accessType, "HARDWARE", "ROMSIMPLE8BIT",  emulator.ROMSIMPLE8BIT);
         AccessIniFileString(ini, accessType, "HARDWARE", "ROMSIMPLE16BIT", emulator.ROMSIMPLE16BIT);
         AccessIniFileString(ini, accessType, "HARDWARE", "ROMSIMPLECF",    emulator.ROMSIMPLECF);
-
-        AccessIniFileInteger(ini, accessType, "HARDWARE", "MDVNoDrives", Hwform.MDVNoDrives);
-
-        for (int i = 0; i < 8; i++)
-        {
-                AccessIniFileString(ini, accessType, "HARDWARE", "MDV" + AnsiString(i), Hwform.MDV[i]);
-        }
 
         AccessIniFileBoolean(ini, accessType, "HARDWARE", "divIDEJumperE", Hwform.DivIDEJumperEClosedChecked);
         AccessIniFileBoolean(ini, accessType, "HARDWARE", "ZXCFJumper",    Hwform.ZXCFUploadJumperOpenedChecked);

--- a/Source/HW_.h
+++ b/Source/HW_.h
@@ -69,11 +69,6 @@ struct HWFormValues
         AnsiString DriveATypeText;
         AnsiString DriveBTypeText;
         AnsiString ZXCFRAMText;
-        AnsiString HD0;
-        AnsiString HD1;
-        AnsiString DriveA;
-        AnsiString DriveB;
-        AnsiString MDV[8];
         bool ZXpandChecked;
         bool SpecDrumChecked;
         bool ProtectROMChecked;
@@ -91,7 +86,6 @@ struct HWFormValues
         bool FloatingPointHardwareFixChecked;
         bool UploadChecked;
         bool uSourceChecked;
-        int MDVNoDrives;
 };
 
 class THW : public TForm

--- a/Source/Plus3Drives.cpp
+++ b/Source/Plus3Drives.cpp
@@ -47,6 +47,8 @@ void TP3Drive::LoadSettings(TIniFile *ini)
 
         ATA_LoadHDF(0, AnsiString(ini->ReadString("P3DRIVE", "HD0", "")).c_str());
         ATA_LoadHDF(1, AnsiString(ini->ReadString("P3DRIVE", "HD1", "")).c_str());
+        ATA_SetReadOnly(0, ini->ReadBool("P3DRIVE", "HD0RO", FALSE));
+        ATA_SetReadOnly(1, ini->ReadBool("P3DRIVE", "HD1RO", FALSE));
 
         DriveAText->Text = ini->ReadString("P3DRIVE", "DriveA", "< Empty >");
         DriveBText->Text = ini->ReadString("P3DRIVE", "DriveB", "< Empty >");
@@ -69,6 +71,8 @@ void TP3Drive::SaveSettings(TIniFile *ini)
 
         ini->WriteString("P3DRIVE", "HD0", ATA_GetHDF(0) ? ATA_GetHDF(0) : "");
         ini->WriteString("P3DRIVE", "HD1", ATA_GetHDF(1) ? ATA_GetHDF(1) : "");
+        ini->WriteBool("P3DRIVE", "HD0RO", ATA_GetReadOnly(0));
+        ini->WriteBool("P3DRIVE", "HD1RO", ATA_GetReadOnly(1));
 
         ini->WriteString("P3DRIVE", "DriveA", DriveAText->Text);
         ini->WriteString("P3DRIVE", "DriveB", DriveBText->Text);

--- a/Source/Plus3Drives.cpp
+++ b/Source/Plus3Drives.cpp
@@ -45,6 +45,18 @@ void TP3Drive::LoadSettings(TIniFile *ini)
         Left = ini->ReadInteger("P3DRIVE", "Left", Left);
         OpenDialogFloppyDiskImage->FileName = ini->ReadString("P3DRIVE", "LastFile", OpenDialogFloppyDiskImage->FileName);
 
+        ATA_LoadHDF(0, AnsiString(ini->ReadString("P3DRIVE", "HD0", "")).c_str());
+        ATA_LoadHDF(1, AnsiString(ini->ReadString("P3DRIVE", "HD1", "")).c_str());
+
+        DriveAText->Text = ini->ReadString("P3DRIVE", "DriveA", "< Empty >");
+        DriveBText->Text = ini->ReadString("P3DRIVE", "DriveB", "< Empty >");
+
+        IF1->MDVNoDrives = ini->ReadInteger("P3DRIVE", "MDVNoDrives", 0);
+        for (int i = 0; i < 8; i++)
+        {
+                IF1->MDVSetFileName(i, AnsiString(ini->ReadString("P3DRIVE", "MDV" + AnsiString(i), "")).c_str());
+        }
+
         if (Form1->DiskDrives1->Checked) Show();
 }
 //---------------------------------------------------------------------------
@@ -54,6 +66,20 @@ void TP3Drive::SaveSettings(TIniFile *ini)
         ini->WriteInteger("P3DRIVE", "Top", Top);
         ini->WriteInteger("P3DRIVE", "Left", Left);
         ini->WriteString("P3DRIVE", "LastFile", OpenDialogFloppyDiskImage->FileName);
+
+        ini->WriteString("P3DRIVE", "HD0", ATA_GetHDF(0) ? ATA_GetHDF(0) : "");
+        ini->WriteString("P3DRIVE", "HD1", ATA_GetHDF(1) ? ATA_GetHDF(1) : "");
+
+        ini->WriteString("P3DRIVE", "DriveA", DriveAText->Text);
+        ini->WriteString("P3DRIVE", "DriveB", DriveBText->Text);
+
+        ini->WriteInteger("P3DRIVE", "MDVNoDrives", IF1->MDVNoDrives);
+        for (int i = 0; i < 8; i++)
+        {
+                ini->WriteString("P3DRIVE", "MDV" + AnsiString(i),
+                        IF1->MDVGetFileName(i) ? IF1->MDVGetFileName(i) : "");
+        }
+
 }
 //---------------------------------------------------------------------------
 
@@ -289,9 +315,6 @@ void __fastcall TP3Drive::FormShow(TObject *Sender)
 
 void TP3Drive::ConfigureFloppyDriveGroup()
 {
-        DriveAText->Text = "< Empty >";
-        DriveBText->Text = "< Empty >";
-
         if (strlen(spectrum.driveaimg)) DriveAText->Text = spectrum.driveaimg;
         if (strlen(spectrum.drivebimg)) DriveBText->Text = spectrum.drivebimg;
 

--- a/Source/floppy.c
+++ b/Source/floppy.c
@@ -61,7 +61,7 @@ u765_SetRandomMethodT u765_SetRandomMethod;
 void LoadFDC765DLL(void)
 {
         USEFDC765DLL=1;
-        if ((DLLHandle=LoadLibrary("fdc765")) != 0) { USEFDC765DLL=0; return; }
+        if ((DLLHandle=LoadLibrary("fdc765")) == NULL) { USEFDC765DLL=0; return; }
         if ((u765_Initialise=(u765_InitialiseT)GetProcAddress(DLLHandle,"u765_Initialise")) == 0) USEFDC765DLL=0;
         if ((u765_InsertDisk=(u765_InsertDiskT)GetProcAddress(DLLHandle,"u765_InsertDisk")) == 0) USEFDC765DLL=0;
         if ((u765_EjectDisk=(u765_EjectDiskT)GetProcAddress(DLLHandle,"u765_EjectDisk")) == 0) USEFDC765DLL=0;

--- a/Source/floppy.c
+++ b/Source/floppy.c
@@ -374,6 +374,8 @@ void floppy_ClockTick(int ts)
 
 void floppy_shutdown()
 {
+        floppy_eject(0);
+        floppy_eject(1);
 
         if (USEFDC765DLL) u765_Shutdown();
         if (DLLHandle) FreeLibrary(DLLHandle);

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -711,6 +711,9 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
 
         Dbg->DisableMemoryWindowAutoUpdates();
 
+        P3Drive->DriveAEjectBtnClick(NULL);
+        P3Drive->DriveBEjectBtnClick(NULL);
+
         char escKey = 27;
         if (FullScreen) FormKeyPress(NULL, escKey);
         if (machine.exit) machine.exit();
@@ -728,9 +731,6 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
                 SaveSettings(ini);
                 delete ini;
         }
-
-        P3Drive->DriveAEjectBtnClick(NULL);
-        P3Drive->DriveBEjectBtnClick(NULL);
 
         RenderEnd();
 

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -711,6 +711,9 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
 
         Dbg->DisableMemoryWindowAutoUpdates();
 
+        char escKey = 27;
+        if (FullScreen) FormKeyPress(NULL, escKey);
+        
         if (!Restart)
         {
                 ini = new TIniFile(emulator.inipath);
@@ -721,8 +724,6 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
         P3Drive->DriveAEjectBtnClick(NULL);
         P3Drive->DriveBEjectBtnClick(NULL);
 
-        char escKey = 27;
-        if (FullScreen) FormKeyPress(NULL, escKey);
         if (machine.exit) machine.exit();
 
         emulation_stop=true;

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -711,6 +711,13 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
 
         Dbg->DisableMemoryWindowAutoUpdates();
 
+        if (!Restart)
+        {
+                ini = new TIniFile(emulator.inipath);
+                SaveSettings(ini);
+                delete ini;
+        }
+
         P3Drive->DriveAEjectBtnClick(NULL);
         P3Drive->DriveBEjectBtnClick(NULL);
 
@@ -724,13 +731,6 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
         PCAllKeysUp();
 
         Sound.End();
-
-        if (!Restart)
-        {
-                ini = new TIniFile(emulator.inipath);
-                SaveSettings(ini);
-                delete ini;
-        }
 
         RenderEnd();
 

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -721,9 +721,6 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
                 delete ini;
         }
 
-        P3Drive->DriveAEjectBtnClick(NULL);
-        P3Drive->DriveBEjectBtnClick(NULL);
-
         if (machine.exit) machine.exit();
 
         emulation_stop=true;

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -711,7 +711,7 @@ void __fastcall TForm1::FormClose(TObject *Sender, TCloseAction &Action)
 
         Dbg->DisableMemoryWindowAutoUpdates();
 
-        char escKey = 27;
+        char escKey = VK_ESCAPE;
         if (FullScreen) FormKeyPress(NULL, escKey);
         
         if (!Restart)


### PR DESCRIPTION
The drive information is more dynamic than hardware and should not be tied to making HW changes. Moved it out of HW and back into where it is managed.