### PR TITLE
Added Restore button to HW dialog to easily return to the current settings

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -4639,3 +4639,9 @@ void __fastcall THW::ZXCFRAMChange(TObject *Sender)
 }
 //---------------------------------------------------------------------------
 
+void __fastcall THW::RestoreButtonClick(TObject *Sender)
+{
+        LoadFromInternalSettings();  // restore form settings from copy
+}
+//---------------------------------------------------------------------------
+

--- a/Source/HW_.dfm
+++ b/Source/HW_.dfm
@@ -1299,7 +1299,7 @@ object HW: THW
     Height = 25
     Anchors = [akRight, akBottom]
     Caption = 'OK'
-    TabOrder = 4
+    TabOrder = 5
     OnClick = OKClick
   end
   object Cancel: TButton
@@ -1309,7 +1309,7 @@ object HW: THW
     Height = 25
     Anchors = [akRight, akBottom]
     Caption = 'Cancel'
-    TabOrder = 5
+    TabOrder = 6
     OnClick = CancelClick
   end
   object RamPackBox: TComboBox
@@ -2119,15 +2119,25 @@ object HW: THW
     OnClick = DefaultsButtonClick
   end
   object Apply: TButton
-    Left = 340
+    Left = 339
     Top = 363
     Width = 75
     Height = 25
     Anchors = [akLeft, akBottom]
     Caption = 'Apply'
     Enabled = False
-    TabOrder = 6
+    TabOrder = 7
     OnClick = ApplyClick
+  end
+  object RestoreButton: TButton
+    Left = 84
+    Top = 363
+    Width = 75
+    Height = 25
+    Anchors = [akLeft, akBottom]
+    Caption = 'Restore'
+    TabOrder = 4
+    OnClick = RestoreButtonClick
   end
   object RomSelect: TOpenDialog
     DefaultExt = '.rom'

--- a/Source/HW_.h
+++ b/Source/HW_.h
@@ -195,6 +195,7 @@ __published:	// IDE-managed Components
         TButton *DefaultsButton;
         TCheckBox *Spectrum128Keypad;
         TButton *Apply;
+        TButton *RestoreButton;
         void __fastcall OKClick(TObject *Sender);
         void __fastcall ZX80BtnClick(TObject *Sender);
         void __fastcall ZX81BtnClick(TObject *Sender);
@@ -272,6 +273,7 @@ __published:	// IDE-managed Components
         void __fastcall ProtectROMClick(TObject *Sender);
         void __fastcall Issue2Click(TObject *Sender);
         void __fastcall ZXCFRAMChange(TObject *Sender);
+        void __fastcall RestoreButtonClick(TObject *Sender);
 private:	// User declarations
         int RamPackHeight;
         int NewMachine, NewSpec;


### PR DESCRIPTION
I think the Restore button completes the needed functionality on the box.
The Apply button works really well, and Restore will bring users back to their starting point if needed.