### PR TITLE
The RamPackTextBox must return -1 if it isn't pertinent

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -329,7 +329,7 @@ void THW::LoadFromInternalSettings()
                 JoystickBox->Items->Add("ZXpand");
         }
 
-        RamPackBox->ItemIndex            = SelectEntry(RamPackBox,            Hwform.RamPackBoxText);
+        RamPackBox->ItemIndex            = FindEntry(RamPackBox,            Hwform.RamPackBoxText);
         SoundCardBox->ItemIndex          = SelectEntry(SoundCardBox,          Hwform.SoundCardBoxText);
         ChrGenBox->ItemIndex             = SelectEntry(ChrGenBox,             Hwform.ChrGenBoxText);
         HiResBox->ItemIndex              = SelectEntry(HiResBox,              Hwform.HiResBoxText);


### PR DESCRIPTION
There are cases when using SelectEntry forces RamPackTextBox to 0 when it should be -1 because it is not pertinent. This causes the Apply button to indicate that there are changes when there are none.