### PR TITLE
IDE selection no longer changes machine ROM

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -4742,6 +4742,7 @@ void THW::UpdateApplyButton()
         ResetRequired |= settingsChanged;
 
         Apply->Enabled = settingsChanged | ResetRequired;
+        RestoreButton->Enabled = Apply->Enabled;
 }
 //---------------------------------------------------------------------------
 

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -1746,16 +1746,11 @@ AnsiString THW::DetermineRomBase()
         romBase += romsFolder;
         AnsiString rom = romBase + machine.CurRom;
 
-        if (FileExists(machine.CurRom))
-        {
-                rom = machine.CurRom;
-        }
-        if (!FileExists(rom))
+        if (!FileExists(machine.CurRom) && !FileExists(rom))
         {
                 romBase = emulator.cwd;
                 romBase += romsFolder;
                 romBase += replacementRomsFolder;
-                rom = romBase + machine.CurRom;
         }
 
         return romBase;
@@ -3788,7 +3783,6 @@ void __fastcall THW::IDEBoxChange(TObject *Sender)
         }
 
         LoadIdeRomBox();
-        LoadRomBox();
 
         DisplayTotalRam();
 

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -346,6 +346,7 @@ void THW::LoadFromInternalSettings()
                 JoystickBox->Items->Add("ZXpand");
         }
 
+        RomBox->ItemIndex                = FindEntry(RomBox,                  Hwform.RomBoxText);
         RamPackBox->ItemIndex            = FindEntry(RamPackBox,              Hwform.RamPackBoxText);
         SoundCardBox->ItemIndex          = SelectEntry(SoundCardBox,          Hwform.SoundCardBoxText);
         ChrGenBox->ItemIndex             = SelectEntry(ChrGenBox,             Hwform.ChrGenBoxText);


### PR DESCRIPTION
We have removed the dependencies between the IDE selection and machine ROM, so ROM should not be reset when selecting IDE options.
Machine ROM was not being restored properly when the Restore button was pushed. Fixed restore ROM setting and only enabled Restore button when changes are pending.
Simplified the logic in DetermineRomBase().