### PR TITLE
Do not stop checking for extensions after seeing a ')'

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -311,8 +311,6 @@ void THW::UpdateHardwareSettings(bool disableReset)
 
         if (Dbg->Visible) Dbg->UpdateVals();
 
-        ReInitialiseSound();
-
         SaveToInternalSettings(); // save copy to keep user choices
         ZX97Dialog->UpdateMachine(Hwform.ZX97Form);
 

--- a/Source/Plus3Drives.cpp
+++ b/Source/Plus3Drives.cpp
@@ -51,12 +51,16 @@ void TP3Drive::LoadSettings(TIniFile *ini)
         ATA_SetReadOnly(1, ini->ReadBool("DRIVES", "HD1RO", FALSE));
 
         DriveAText->Text = ini->ReadString("DRIVES", "DriveA", "< Empty >");
+        if ((DriveAText->Text != "< Empty >") && !FileExists(DriveAText->Text))
+                DriveAText->Text = "< Empty >";
         DriveBText->Text = ini->ReadString("DRIVES", "DriveB", "< Empty >");
+        if ((DriveBText->Text != "< Empty >") && !FileExists(DriveBText->Text))
+                DriveBText->Text = "< Empty >";
 
         IF1->MDVNoDrives = ini->ReadInteger("DRIVES", "MDVNoDrives", 0);
         for (int i = 0; i < 8; i++)
         {
-                IF1->MDVSetFileName(i, AnsiString(ini->ReadString("DRIVES", "MDV" + AnsiString(i), "")).c_str());
+                IF1->MDVSetFileName(i, AnsiString(ini->ReadString("DRIVES", "MDV" + AnsiString(i), "< Empty >")).c_str());
         }
 
         if (Form1->DiskDrives1->Checked) Show();
@@ -81,7 +85,7 @@ void TP3Drive::SaveSettings(TIniFile *ini)
         for (int i = 0; i < 8; i++)
         {
                 ini->WriteString("DRIVES", "MDV" + AnsiString(i),
-                        IF1->MDVGetFileName(i) ? IF1->MDVGetFileName(i) : "");
+                        IF1->MDVGetFileName(i) ? IF1->MDVGetFileName(i) : "< Empty >");
         }   
 }
 //---------------------------------------------------------------------------

--- a/Source/ZipFile_.cpp
+++ b/Source/ZipFile_.cpp
@@ -49,7 +49,7 @@ AnsiString TZipFile::ExpandZIP(AnsiString Path, AnsiString DialogueFilter)
         // Now search the text for a * or a , indicating the start of an extension
         // eg *.TZX or .t81
 
-        while(*Orig!='\0' && *Orig!=')')
+        while(*Orig!='\0')
         {
                 if (Orig[0]=='*' && Orig[1]=='.')
                 {
@@ -57,7 +57,7 @@ AnsiString TZipFile::ExpandZIP(AnsiString Path, AnsiString DialogueFilter)
                         // when we reach a | ; or the EOL.
 
                         Orig++;
-                        while(*Orig!='|' && *Orig!=';' && *Orig!='\0' && *Orig!=')') *(Dest++) = *(Orig++);
+                        while(*Orig!='|' && *Orig!=';' && *Orig!='\0') *(Dest++) = *(Orig++);
                         *(Dest++)='\0';
                 }
                 else    Orig++;

--- a/Source/main_.cpp
+++ b/Source/main_.cpp
@@ -776,7 +776,6 @@ void __fastcall TForm1::Timer2Timer(TObject *Sender)
         if (Form1->Handle != OldhWnd)
         {
                 OldhWnd=Form1->Handle;
-                Sound.ReInitialise(OldhWnd, 0,0,0,0);
 
                 RenderEnd();
                 RenderInit();

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -473,7 +473,7 @@ void CSound::AYWrite128(int reg, int val, int frametstates)
 
         AYWrite(reg, val, frametstates);
 
-        if (reg == 14) // && ((AYRegisterStore[7] & 0x40) == 0x40))
+        if ((reg == 14) && ((AYRegisterStore[7] & 0x40) == 0x40))
         {
                 Midi.WriteBit(val);
 


### PR DESCRIPTION
- Fixes a bug I introduced while tracking down a different problem.
- Upon startup, do not try to reconnect files that were temporarily created when uncompressed in a prior session.
- Indicate Microdrives as being Empty when not connected to a file.
- Fixed sound subsystem reset behavior (which also fixes 128 keypad startup)