### PR TITLE
Control output to AY Port A

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -1271,7 +1271,11 @@ void THW::ConfigureKeypad()
 
         if (!Form1->ConnectSpectrum128Keypad->Enabled)
         {
-                Form1->ConnectSpectrum128Keypad->Checked = false;
+                spectrum.spectrum128Keypad = 0;
+        }
+        else
+        {
+                spectrum.spectrum128Keypad = (CFGBYTE)(Form1->ConnectSpectrum128Keypad->Checked ? 1 : 0);
         }
 }
 

--- a/Source/sound/sound.cpp
+++ b/Source/sound/sound.cpp
@@ -473,13 +473,13 @@ void CSound::AYWrite128(int reg, int val, int frametstates)
 
         AYWrite(reg, val, frametstates);
 
-        if ((reg == 14) && ((AYRegisterStore[7] & 0x40) == 0x40))
+        if ((AYRegisterStore[7] & 0x40) == 0x40)
         {
-                Midi.WriteBit(val);
+                Midi.WriteBit(AYRegisterStore[14]);
 
                 if (spectrum.spectrum128Keypad)
                 {
-                        Keypad.Write(val);
+                        Keypad.Write(AYRegisterStore[14]);
                 }
 
                 // This should also handle writing RS232 data (unless handled elsewhere already???)


### PR DESCRIPTION
Drive value of register 14 to the Port A output receivers. Controlling the port lines and reacting to any change more accurately emulates the port behavior. This should have minimal performance impact.
Another change is to correct the behavior of the Spectrum 128 keypad enabled and have it track properly with the machine pertinency and checkbox setting.