### PR TITLE
Honor disable reset request on hardware update

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -287,7 +287,11 @@ void THW::UpdateHardwareSettings(bool disableReset)
         Form1->ConnectSpectrum128Keypad->Hint = StringReplace(Form1->ConnectSpectrum128Keypad->Hint, "#", GetKeypadMultiplyKey(), TReplaceFlags() << rfReplaceAll);
         Kb->UpdateCursors();
 
-        if (ResetRequired && !disableReset)
+        if (disableReset)
+        {
+                ResetRequired = false;
+        }
+        else if (ResetRequired)
         {
                 machine.initialise();
                 ResetRequired = false;

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -4826,7 +4826,7 @@ void THW::UpdateApplyButton()
 
         ResetRequired |= settingsChanged;
 
-        Apply->Enabled = settingsChanged | ResetRequired;
+        Apply->Enabled = ResetRequired;
         RestoreButton->Enabled = Apply->Enabled;
 }
 //---------------------------------------------------------------------------

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -3442,8 +3442,12 @@ void THW::AccessIniFile(TIniFile* ini, IniFileAccessType accessType)
 {
         //---- MACHINE ----
 
-        AccessIniFileInteger(ini, accessType, "HARDWARE", "Top",  Top);
-        AccessIniFileInteger(ini, accessType, "HARDWARE", "Left", Left);
+        int temp=Top;
+        AccessIniFileInteger(ini, accessType, "HARDWARE", "Top",  temp);
+        Top=temp;
+        temp=Left;
+        AccessIniFileInteger(ini, accessType, "HARDWARE", "Left", temp);
+        Left=temp;
 
         AccessIniFileString(ini, accessType, "HARDWARE", "MachineName", Hwform.MachineName);
 

--- a/Source/zx97Config.cpp
+++ b/Source/zx97Config.cpp
@@ -98,8 +98,12 @@ void TZX97Dialog::LoadSettings(TIniFile *ini)
 
 void TZX97Dialog::AccessIniFile(TIniFile* ini, IniFileAccessType accessType)
 {
-        AccessIniFileInteger(ini, accessType, "ZX97", "Top",   Top);
-        AccessIniFileInteger(ini, accessType, "ZX97", "Left",  Left);
+        int temp=Top;
+        AccessIniFileInteger(ini, accessType, "ZX97", "Top",   temp);
+        Top=temp;
+        temp=Left;
+        AccessIniFileInteger(ini, accessType, "ZX97", "Left",  temp);
+        Left=temp;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Fixed the saving and storing of window positions that use AccessIniFileInteger to read and write variables by reference. This doesn't properly update form properties which require direct assignment.