### PR TITLE
Fixed fast load/save patch settings for Lambda 8300

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -4,12 +4,14 @@ This can be done manually or via Options > Configuration > Reset To Default Sett
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Version 1.42 - 10/03/2025 (by John Stroebel and Paul Farrow)
+Version 1.42 - 30/03/2025 (by John Stroebel and Paul Farrow)
 * Bug fixes:
   - Bottom 3 volume levels of AY sound output were being capped to 0.
   - The Apply button was not being enabled after browsing for a ROM cartridge file.
   - Removed a redundant initialisation call to the sound subsystem.
   - Fixed inconsistent coverage and content between rendering modes whilst FullScreen.
+  - Fixed fast load/save operation on Lambda 8300 version 1 ROM.
+  - Default button ROM setting for Lambda 8300 did not match program default.
 * Enhancements:
   - Added an Automatic selection to Fullscreen display options, which uses the screen
     resolution detected at application start. Also changed default width setting to

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -4786,7 +4786,7 @@ void THW::SelectDefaultRom()
                 break;
 
         case MACHINELAMBDA:
-                RomBox->Text = "lambda8300.rom";
+                RomBox->Text = "lambda8300colour.rom";
                 break;
 
         case MACHINEZX97LE:

--- a/Source/zx81/rompatch.cpp
+++ b/Source/zx81/rompatch.cpp
@@ -214,7 +214,14 @@ void InitPatches(int machineType)
                 patches[0x01cb11] = ZX80OutByteSaveByte;
                 patches[0x0203c3] = ZX80ZX81LambdaStopTape;
         }
-        else if (machineType == MACHINELAMBDA)
+        else if ((machineType == MACHINELAMBDA) && (emulator.romcrc == CRCLAMBDA))
+        {
+                patches[0x038ccd] = LambdaSaveDelayStartSaving;
+                patches[0x03e31f] = ZX81LambdaGetByteStartLoading;
+                patches[0x03ab5e] = ZX81LambdaOutByteSaveByte;
+                patches[0x0221fd] = ZX80ZX81LambdaStopTape;
+        }
+        else if ((machineType == MACHINELAMBDA) && (emulator.romcrc == CRCLAMBDACOLOUR))
         {
                 patches[0x0d0d16] = LambdaSaveDelayStartSaving;
                 patches[0x19b307] = ZX81LambdaGetByteStartLoading;


### PR DESCRIPTION
- Added missing fast load/save patch settings for Lambda 8300 version 1 ROM.
- Fixed mismatch between program default and Default button Lambda ROM setting.
- Updated Release History.