### PR TITLE
Relaxed IO port decoding of high-byte for 0xFD low-byte

### DIFF
--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -1779,7 +1779,7 @@ void THW::ConfigureMachineSettings()
                 {
                         machine.clockspeed = 3546900;
                         machine.tperscanline = 228;
-                        spectrum.interruptPosition = 14336-228+32;
+                        spectrum.interruptPosition = 14336+32;
                         machine.scanlines = 311;
                         machine.fps = 50;
                         machine.tperframe = machine.tperscanline * machine.scanlines;

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -1218,23 +1218,23 @@ void spec48_writeport(int Address, int Data, int *tstates)
                 if (machine.zxprinter) ZXPrinterWritePort((unsigned char)Data);
                 break;
         case 0xfd:
-                switch(Address>>8)
+                switch ((Address>>8)&0xf0)
                 {
-                case 0x0f:
+                case 0x00:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 PrinterWriteData((unsigned char)Data);
                         }
                         break;
 
-                case 0x3f:
+                case 0x30:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 floppy_write_datareg((BYTE)Data);
                         }
                         break;
 
-                case 0x7f:
+                case 0x70:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCY128)
                         {
                                 if (!SPECBankEnable) break;
@@ -1250,7 +1250,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                         }
                         break;
 
-                case 0x1f:
+                case 0x10:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 machine.drivebusy = (Data&8) ? 1:0;
@@ -1280,7 +1280,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                                 }
                         }
                         break;
-                case 0xbf:
+                case 0xb0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR &&
                             ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCY128)))
                         {
@@ -1288,7 +1288,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                         }
                         break;
 
-                case 0xff:
+                case 0xf0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR &&
                             ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCY128)))
                         {
@@ -1613,15 +1613,15 @@ BYTE ReadPort(int Address, int *tstates)
                 break;
 
         case 0xfd:
-                switch((Address>>8)&255)
+                switch((Address>>8)&0xf0)
                 {
-                case 0x0f:
+                case 0x00:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return (BYTE)PrinterBusy();
                         }
                         break;
-                case 0xff:
+                case 0xf0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR)
                         {
                                 if ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCYPLUS2A))
@@ -1634,13 +1634,13 @@ BYTE ReadPort(int Address, int *tstates)
                                 }
                         }
                         break;
-                case 0x3f:
+                case 0x30:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return(floppy_read_datareg());
                         }
                         break;
-                case 0x2f:
+                case 0x20:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return(floppy_read_statusreg());

--- a/Source/z80/z80.c
+++ b/Source/z80/z80.c
@@ -51,6 +51,7 @@ BYTE parity_table[0x100]; /* The parity of the lookup value */
 BYTE sz53p_table[0x100]; /* OR the above two tables together */
 
 int nmiOccurred;
+extern int interruptLatchEnable;
 
 extern int StackChange;
 extern int StepOutRequested;
@@ -108,13 +109,9 @@ void z80_reset( void )
 /* Process a z80 maskable interrupt */
 int z80_interrupt(int bus)
 {
-        if (IFF1)
+        if (IFF1 && interruptLatchEnable!=0)
         {
-                if (z80.halted)
-                {
-                        PC++;
-                        z80.halted = 0;
-                }
+                z80.halted = 0;
 
                 IFF1 = 0;
                 IFF2 = 0;
@@ -160,23 +157,24 @@ int z80_interrupt(int bus)
 /* Process a z80 non-maskable interrupt */
 int z80_nmi()
 {
-        StackChange += 2;
-        IFF1 = 0;
-
-        if (z80.halted)
+        if (interruptLatchEnable!=0)
         {
+                StackChange += 2;
+                IFF1 = 0;
+
                 z80.halted=0;
-                PC++;
+
+                writebyte(--SP, PCH);
+                writebyte(--SP, PCL);
+
+                numberOfM1Cycles++;
+                R++;
+                PC = 0x0066;
+
+                nmiOccurred = 0;
+
+                return 11;
         }
-
-        writebyte(--SP, PCH);
-        writebyte(--SP, PCL);
-
-        numberOfM1Cycles++;
-        R++;
-        PC = 0x0066;
-
-        nmiOccurred = 0;
-
-        return 11;
+        else
+                return 0;
 }

--- a/Source/z80/z80_ddfd.c
+++ b/Source/z80/z80_ddfd.c
@@ -566,5 +566,7 @@ break;
 default:		/* Instruction did not involve H or L, so backtrack
 			   one instruction and parse again */
 PC--;			/* FIXME: will be contended again */
+tstates-=4;             /* Also, recover tstates */ 
 R--;			/* Decrement the R register as well */
+interruptLatchEnable=0; /* Delay interrupt sampling */
 break;

--- a/Source/z80/z80_ops.c
+++ b/Source/z80/z80_ops.c
@@ -50,6 +50,7 @@ extern int StackChange;
 static int mCycles[maxMCycles];
 static int mCycleIndex ;
 static int inputOutputMCycle;
+int interruptLatchEnable;
 int numberOfM1Cycles;
 
 void InsertMCycle(int cycleLength)
@@ -100,6 +101,7 @@ int z80_do_opcode()
 
     tstates=0;
     RetExecuted = 0;
+    interruptLatchEnable = 1;
 
     /* Do the instruction fetch; opcode_fetch used here to avoid
        triggering read breakpoints */
@@ -107,9 +109,12 @@ int z80_do_opcode()
     InsertMCycle(4);
     contend( PC, 4 ); R++; RZXCounter--;
 
-    //if (z80.halted) opcode=0;
     numberOfM1Cycles = 1;
-    opcode = opcode_fetch( PC++ );
+    opcode = opcode_fetch( PC );
+    if (z80.halted)
+        opcode = 0x00;  /* No PC increment and always NOP while halted */
+    else
+        PC++;
 
     switch(opcode) {
     case 0x00:		/* NOP */
@@ -643,7 +648,6 @@ int z80_do_opcode()
       break;
     case 0x76:		/* HALT */
       z80.halted=1;
-      PC--;
       break;
     case 0x77:		/* LD (HL),A */
       InsertMCycle(3);
@@ -1299,6 +1303,7 @@ int z80_do_opcode()
       break;
     case 0xfb:		/* EI */
       IFF1=IFF2=1;
+      interruptLatchEnable=0; /* Delay interrupt sampling */
       break;
     case 0xfc:		/* CALL M,nnnn */
       InsertMCycle(3);

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -989,7 +989,7 @@ BYTE zx81_opcode_fetch(int Address)
         static bool startOfDFile = true;
         static int calls = 0;
         int inv;
-        int bit6, update=0;
+        int bit6;
         BYTE opcode, data;
 
         // very rough timing here;
@@ -1046,7 +1046,6 @@ BYTE zx81_opcode_fetch(int Address)
         // generate the TV picture (exactly how depends on which
         // display method is used)
 
-        if (!bit6) opcode=0;
         inv = data&128;
 
         bool zx80 = (emulator.machine == MACHINEZX80);
@@ -1068,7 +1067,6 @@ BYTE zx81_opcode_fetch(int Address)
                 FetchChromaColour(Address, data, lineCounter, memory);
 
                 data=zx81_ReadByte((z80.i<<8) | (z80.r7 & 128) | ((z80.r-1) & 127));
-                update=1;
         }
         else if ((z80.i&1) && (zx81.truehires==HIRESMEMOTECH) && MemotechMode)
         {
@@ -1083,15 +1081,14 @@ BYTE zx81_opcode_fetch(int Address)
                 if (!startOfDFile && (rRegister != 0x80 && rRegister != 0x81))
                 {
                         inv=(MemotechMode==3);
-                        update=1;
+                        bit6 = 0;
                 }
         }
         else if (zx81.truehires==HIRESQUICKSILVA && QuicksilvaHiResMode && syncOutputWhite)
         {
-                if (opcode!=118)
+                if (!bit6 && !z80.halted)
                 {
                         inv=0;
-                        update=1;
                         data=zx81_ReadByte(QsHiResAddress);
                         QsHiResAddress++;
                         if (QsHiResAddress == 0xB800)
@@ -1108,7 +1105,7 @@ BYTE zx81_opcode_fetch(int Address)
                 // register to generate an interrupt at the right time.
 
                 inv=0;
-                update=1;
+                bit6 = 0;
         }
         else if (!bit6)
         {
@@ -1162,14 +1159,12 @@ BYTE zx81_opcode_fetch(int Address)
                 {
                         data=255;
                 }
-
-                update=1;
         }
 
-        if (update)
+        if (!bit6 && !z80.halted)
         {
-                // Update gets set to true if we managed to fetch a bitmap from
-                // somewhere.  The only time this doesn't happen is if we encountered
+                // We managed to fetch a bitmap from somewhere.
+                // The only time this doesn't happen is if we encountered
                 // an opcode with bit 6 set above M1NOT.
 
                 if (machine.colour == COLOURLAMBDA)

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -988,8 +988,8 @@ BYTE zx81_opcode_fetch(int Address)
 {
         static bool startOfDFile = true;
         static int calls = 0;
-        int inv;
-        int bit6;
+        bool inv;
+        bool bit6;
         BYTE opcode, data;
 
         // very rough timing here;


### PR DESCRIPTION
- Fixed issue #132 by relaxing the decoding of I/O addresses when the lower byte is 0xFD. Now, only the upper four bits of the upper byte (A15-A12) are decoded.
- Fixed Z80 core emulation related to the behavior of HALT and interrupt timing to align with the behavior observable in the [Visual Z80 Remix](https://floooh.github.io/visualz80remix/) emulator. These changes impact EO's ZX81 video implementation and can be observed on programs running on EO's Spectrum emulation. The changes are:
  - The next PC after the HALT instruction will be fetched while HALTed. The prior implementation always fetches the PC of the HALT instruction until an interrupt occurs. Some hardware devices are impacted by this behavior, such as Lambda Colour.
  - Interrupts should not be latched during the prefixed portion of instructions and during the EI instruction. The prefixes that matter are DD and FD since the default case falls back through the main case statement on the next call to z80_do_opcode.
- Updated the ZX81 video ULA emulation to operate with the Z80 changes and align better logically with the ZX81 ULA.