### PR TITLE
Frame improvements for Ace and Speccy

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -7,13 +7,18 @@ This can be done manually or via Options > Configuration > Reset To Default Sett
 Version 1.42 - 01/04/2025 (by John Stroebel and Paul Farrow)
 * Bug fixes:
   - Bottom 3 volume levels of AY sound output were being capped to 0.
+  - Relaxed IO port decoding of high byte for 0xFD low byte on Spectrum machines.
+    Fixes issue of sound not working with various software.
   - The Apply button was not being enabled after browsing for a ROM cartridge file.
   - Removed a redundant initialisation call to the sound subsystem.
   - Fixed inconsistent coverage and content between rendering modes whilst FullScreen.
   - Fixed fast load/save operation on Lambda 8300 version 1 ROM.
   - Default button ROM setting for Lambda 8300 did not match program default.
   - Corrected typo and formatting of the Lambda 8300 colour interface instructions.
-  - Fixed stuck keys when application loses focus.
+  - Fixed stuck keys when the application loses focus.
+  - Fixed incorrect Z80 behavior related to interrupts and halting.
+  - Fixed incorrect frame alignment and timing on Ace and Spectrum machines.
+  - Fixed an issue with flash loads on Ace and Spectrum machines when end of file is reached.
 * Enhancements:
   - Added an Automatic selection to Fullscreen display options, which uses the screen
     resolution detected at application start. Also changed default width setting to

--- a/Source/Ace/ace.cpp
+++ b/Source/Ace/ace.cpp
@@ -67,6 +67,10 @@ extern BYTE ZXKeyboard[8];
 int ACEMICState, ACETopBorder, ACELeftBorder;
 BYTE acecolour[1024], acelatch=4;
 
+static int loop;
+static int fts,sts, chars;
+static int Sy;
+
 static BYTE ReadInputPort(int Address, int *tstates);
 static BYTE idleDataBus = 0x20;
 
@@ -116,6 +120,9 @@ void ace_initialise()
 
 void ace_reset()
 {
+        loop=machine.tperscanline;
+        fts=sts=chars=0;
+        Sy=0;
         z80_reset();
         InitialiseJoysticks();
         Form1->BuildMenuJoystickSelection();
@@ -355,11 +362,11 @@ int ace_do_scanline(SCANLINE *CurScanLine)
 {
         int ts,i;
         static int ink,paper;
-        static int Sy=0, loop=207;
         static int borrow=0;
-        static int fts=0, sts=0, chars=0, delay=0;
+        static int delay=0;
         static int shift_register;
         static int clean_exit=1;
+        static int IntDue=0, IntPending=0;
         int inv,bitmap,chr, attr;
         int MaxScanLen;
         int PrevBit=0, PrevGhost=0;
@@ -392,13 +399,21 @@ int ace_do_scanline(SCANLINE *CurScanLine)
 
                 if (z80.pc.w==0x1820) WavStartRec();
 
-                ts=z80_do_opcode();
-                if (!fts)
+                ts=0;
+                if (fts>0 && IntDue)
                 {
-                        int intlen=z80_interrupt(idleDataBus);
-                        ts+=intlen;
-                        if (intlen) WavStop();
+                        ts+=z80_interrupt(idleDataBus);
+                        IntDue=0;
+                        IntPending=1664-fts+1;
                 }
+                else if (IntPending>0)
+                        ts+=z80_interrupt(idleDataBus);
+
+                if (ts) WavStop();
+                else ts+=z80_do_opcode();
+
+                if (IntPending>0)
+                        IntPending-=ts;
 
                 i=70;
                 while(FlashLoading && IsFlashLoadable() && i)
@@ -477,14 +492,14 @@ int ace_do_scanline(SCANLINE *CurScanLine)
                 loop += machine.tperscanline;
 
                 Sy++;
-                if (Sy==311)
+                if (Sy>=machine.scanlines)
                 {
-                        fts=0;
+                        fts -= machine.tperframe;
+                        IntDue = 1;
                         CurScanLine->sync_len=414;
                         CurScanLine->sync_type = SYNCTYPEV;
+                        emulator.scanlinesPerFrame = Sy;
                         Sy=0;
-                        borrow=0;
-                        loop=machine.tperscanline;
                 }
 
                 clean_exit=1;

--- a/Source/Ace/ace.cpp
+++ b/Source/Ace/ace.cpp
@@ -421,6 +421,7 @@ int ace_do_scanline(SCANLINE *CurScanLine)
                         ts=z80_do_opcode();
                         WavClockTick(ts,0);
                         i--;
+                        if (!WavPlaying()) break;
                 }
                 if (!WavPlaying()) FlashLoading=0;
 

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -1779,7 +1779,7 @@ void THW::ConfigureMachineSettings()
                 {
                         machine.clockspeed = 3546900;
                         machine.tperscanline = 228;
-                        spectrum.interruptPosition = 14336+32;
+                        spectrum.interruptPosition = 14336+28;
                         machine.scanlines = 311;
                         machine.fps = 50;
                         machine.tperframe = machine.tperscanline * machine.scanlines;

--- a/Source/HW_.cpp
+++ b/Source/HW_.cpp
@@ -1779,7 +1779,7 @@ void THW::ConfigureMachineSettings()
                 {
                         machine.clockspeed = 3546900;
                         machine.tperscanline = 228;
-                        spectrum.interruptPosition = 14336-228+32;
+                        spectrum.interruptPosition = 14336+32;
                         machine.scanlines = 311;
                         machine.fps = 50;
                         machine.tperframe = machine.tperscanline * machine.scanlines;

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -146,6 +146,11 @@ bool romSp128;
 bool romPlus2;
 bool romPlus3;
 
+static int loop;
+static int sts, chars;
+static int Sy;
+static int DCCount;
+
 BOOL insertWaitsWhileSP0256Busy;
 
 extern AnsiString AdjustPathIfReplacementRom(char* curRom);
@@ -189,6 +194,10 @@ void spec48_reset(void)
         SPECLast7ffd=0;
         SPECLast1ffd=0;
         SPECLastfffd=0;
+        loop=machine.tperscanline;
+        fts=sts=chars=0;
+        Sy=0;
+        DCCount=0;
 
         if (spectrum.model==SPECCYTS2068 || spectrum.model==SPECCYTC2068) SPECBankEnable=0;
         else if (spectrum.model>=SPECCY128) SPECBankEnable=1;
@@ -1731,13 +1740,13 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
 {
         int ts,i;
         static int ink, paper, ink2, paper2;
-        static int Sy=0, loop=207;
         static int borrow=0;
-        static int sts=0, chars=0, delay=0, IntDue=0;
-        static int DrawingBorder=1, DCCount=0;
+        static int delay=0, IntDue=0;
+        static int DrawingBorder=1;
         static int BaseColour, PBaseColour;
         static int shift_register;
         static int clean_exit=1;
+        static int IntPending=0;
         int attr, attr2, b1, b2;
         int MaxScanLen;
         int PrevBit=0, PrevGhost=0;
@@ -1775,8 +1784,6 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
                 delay=SPECLeftBorder - borrow*2;
                 chars=0;
         }
-
-        if (fts<=0) IntDue=1;
 
         MaxScanLen = scale * emulator.single_step? 1:500;
         do
@@ -1822,13 +1829,43 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
 
                 if (!insertWaitsWhileSP0256Busy)
                 {
-                        ts=z80_do_opcode();
+                        ts = 0;
+                        if (fts>InteruptPosition && IntDue)
+                        {
+                                InteruptTime=(TIMEXByte&64)?0:z80_interrupt(idleDataBus);
+                                if (rzx.mode==RZX_PLAYBACK)
+                                {
+                                        rzx_update(&RZXCounter);
+                                }
+
+                                ts+=InteruptTime;
+                                if (++flash >32) flash=0;
+                                DrawingBorder=1;
+                                DCCount = (++DCCount)&3;
+                                IntDue=0;
+                                IntPending=32-(fts-InteruptPosition)+1;
+                                ContendCounter=(fts-InteruptPosition);
+                                ContendCounter= (ContendCounter+1)&~3;
+                        }
+                        else if (IntPending>0)
+                                ts+=(TIMEXByte&64)?0:z80_interrupt(idleDataBus);
+
+                        if (ts)
+                        {
+                                if (!WavInGroup()) WavStop();
+                        }
+                        else
+                        {
+                                ts=z80_do_opcode();
+                        }
                 }
                 else
                 {
                         ts = 1;
                         insertWaitsWhileSP0256Busy = (sp0256_AL2.Busy() && !emulator.single_step) ? true : false;
                 }
+                if (IntPending>0)
+                        IntPending-=ts;
 
                 if (BasicLister->Visible &&
                     ((spectrumBasicRomPagedIn && (z80.pc.w == 0x15AB || (z80.pc.w == 0x0805 && FLAG_C) || z80.pc.w == 0x08F0)) ||
@@ -1902,24 +1939,6 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
 
                 if (!SpeedUpCount)
                 {
-                        if (fts>InteruptPosition && IntDue)
-                        {
-                                InteruptTime=(TIMEXByte&64)?0:z80_interrupt(idleDataBus);
-                                if (rzx.mode==RZX_PLAYBACK)
-                                {
-                                        rzx_update(&RZXCounter);
-                                }
-
-                                if (InteruptTime && !WavInGroup()) WavStop();
-                                ts+=InteruptTime;
-                                if (++flash >32) flash=0;
-                                DrawingBorder=1;
-                                DCCount = (++DCCount)&3;
-                                IntDue=0;
-                                ContendCounter=(fts-InteruptPosition);
-                                ContendCounter= (ContendCounter+1)&~3;
-                        }
-
                         loop-=ts;
                         fts+=ts;
                         sts+=ts;
@@ -2124,12 +2143,12 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
                 Sy++;
                 if (Sy>=machine.scanlines)
                 {
-                        fts = 0;
+                        fts -= machine.tperframe;
+                        IntDue = 1;
                         CurScanLine->sync_len=414;
                         CurScanLine->sync_type = SYNCTYPEV;
                         emulator.scanlinesPerFrame = Sy;
                         Sy=0;
-                        loop=machine.tperscanline;
                 }
 
                 clean_exit=1;

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -1897,6 +1897,7 @@ int spec48_do_scanline(SCANLINE *CurScanLine)
                         ts=z80_do_opcode();
                         WavClockTick(ts,0);
                         i--;
+                        if (!WavPlaying()) break;
                 }
                 if (!WavPlaying()) SPECFlashLoading=0;
 

--- a/Source/Spectrum/spec48.cpp
+++ b/Source/Spectrum/spec48.cpp
@@ -1218,23 +1218,23 @@ void spec48_writeport(int Address, int Data, int *tstates)
                 if (machine.zxprinter) ZXPrinterWritePort((unsigned char)Data);
                 break;
         case 0xfd:
-                switch(Address>>8)
+                switch ((Address>>8)&0xf0)
                 {
-                case 0x0f:
+                case 0x00:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 PrinterWriteData((unsigned char)Data);
                         }
                         break;
 
-                case 0x3f:
+                case 0x30:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 floppy_write_datareg((BYTE)Data);
                         }
                         break;
 
-                case 0x7f:
+                case 0x70:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCY128)
                         {
                                 if (!SPECBankEnable) break;
@@ -1250,7 +1250,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                         }
                         break;
 
-                case 0x1f:
+                case 0x10:
                         if ((emulator.machine == MACHINESPECTRUM) && (spectrum.model >= SPECCYPLUS2A))
                         {
                                 machine.drivebusy = (Data&8) ? 1:0;
@@ -1280,7 +1280,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                                 }
                         }
                         break;
-                case 0xbf:
+                case 0xb0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR &&
                             ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCY128)))
                         {
@@ -1288,7 +1288,7 @@ void spec48_writeport(int Address, int Data, int *tstates)
                         }
                         break;
 
-                case 0xff:
+                case 0xf0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR &&
                             ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCY128)))
                         {
@@ -1613,15 +1613,15 @@ BYTE ReadPort(int Address, int *tstates)
                 break;
 
         case 0xfd:
-                switch((Address>>8)&255)
+                switch((Address>>8)&0xf0)
                 {
-                case 0x0f:
+                case 0x00:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return (BYTE)PrinterBusy();
                         }
                         break;
-                case 0xff:
+                case 0xf0:
                         if (emulator.machine == MACHINESPECTRUM && machine.aytype == AY_TYPE_SINCLAIR)
                         {
                                 if ((spectrum.model >= SPECCY16 && spectrum.model <= SPECCYPLUS) || (spectrum.model >= SPECCYPLUS2A))
@@ -1634,13 +1634,13 @@ BYTE ReadPort(int Address, int *tstates)
                                 }
                         }
                         break;
-                case 0x3f:
+                case 0x30:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return(floppy_read_datareg());
                         }
                         break;
-                case 0x2f:
+                case 0x20:
                         if (emulator.machine == MACHINESPECTRUM && spectrum.model >= SPECCYPLUS2A)
                         {
                                 return(floppy_read_statusreg());

--- a/Source/z80/z80.c
+++ b/Source/z80/z80.c
@@ -51,6 +51,7 @@ BYTE parity_table[0x100]; /* The parity of the lookup value */
 BYTE sz53p_table[0x100]; /* OR the above two tables together */
 
 int nmiOccurred;
+extern int interruptLatchEnable;
 
 extern int StackChange;
 extern int StepOutRequested;
@@ -108,13 +109,9 @@ void z80_reset( void )
 /* Process a z80 maskable interrupt */
 int z80_interrupt(int bus)
 {
-        if (IFF1)
+        if (IFF1 && interruptLatchEnable!=0)
         {
-                if (z80.halted)
-                {
-                        PC++;
-                        z80.halted = 0;
-                }
+                z80.halted = 0;
 
                 IFF1 = 0;
                 IFF2 = 0;
@@ -160,23 +157,24 @@ int z80_interrupt(int bus)
 /* Process a z80 non-maskable interrupt */
 int z80_nmi()
 {
-        StackChange += 2;
-        IFF1 = 0;
-
-        if (z80.halted)
+        if (interruptLatchEnable!=0)
         {
+                StackChange += 2;
+                IFF1 = 0;
+
                 z80.halted=0;
-                PC++;
+
+                writebyte(--SP, PCH);
+                writebyte(--SP, PCL);
+
+                numberOfM1Cycles++;
+                R++;
+                PC = 0x0066;
+
+                nmiOccurred = 0;
+
+                return 11;
         }
-
-        writebyte(--SP, PCH);
-        writebyte(--SP, PCL);
-
-        numberOfM1Cycles++;
-        R++;
-        PC = 0x0066;
-
-        nmiOccurred = 0;
-
-        return 11;
+        else
+                return 0;
 }

--- a/Source/z80/z80_ddfd.c
+++ b/Source/z80/z80_ddfd.c
@@ -566,5 +566,7 @@ break;
 default:		/* Instruction did not involve H or L, so backtrack
 			   one instruction and parse again */
 PC--;			/* FIXME: will be contended again */
+tstates-=4;             /* Also, recover tstates */ 
 R--;			/* Decrement the R register as well */
+interruptLatchEnable=0; /* Delay interrupt sampling */
 break;

--- a/Source/z80/z80_ops.c
+++ b/Source/z80/z80_ops.c
@@ -50,6 +50,7 @@ extern int StackChange;
 static int mCycles[maxMCycles];
 static int mCycleIndex ;
 static int inputOutputMCycle;
+int interruptLatchEnable;
 int numberOfM1Cycles;
 
 void InsertMCycle(int cycleLength)
@@ -100,6 +101,7 @@ int z80_do_opcode()
 
     tstates=0;
     RetExecuted = 0;
+    interruptLatchEnable = 1;
 
     /* Do the instruction fetch; opcode_fetch used here to avoid
        triggering read breakpoints */
@@ -107,9 +109,12 @@ int z80_do_opcode()
     InsertMCycle(4);
     contend( PC, 4 ); R++; RZXCounter--;
 
-    //if (z80.halted) opcode=0;
     numberOfM1Cycles = 1;
-    opcode = opcode_fetch( PC++ );
+    opcode = opcode_fetch( PC );
+    if (z80.halted)
+        opcode = 0x00;  /* No PC increment and always NOP while halted */
+    else
+        PC++;
 
     switch(opcode) {
     case 0x00:		/* NOP */
@@ -643,7 +648,6 @@ int z80_do_opcode()
       break;
     case 0x76:		/* HALT */
       z80.halted=1;
-      PC--;
       break;
     case 0x77:		/* LD (HL),A */
       InsertMCycle(3);
@@ -1299,6 +1303,7 @@ int z80_do_opcode()
       break;
     case 0xfb:		/* EI */
       IFF1=IFF2=1;
+      interruptLatchEnable=0; /* Delay interrupt sampling */
       break;
     case 0xfc:		/* CALL M,nnnn */
       InsertMCycle(3);

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -989,7 +989,7 @@ BYTE zx81_opcode_fetch(int Address)
         static bool startOfDFile = true;
         static int calls = 0;
         int inv;
-        int bit6, update=0;
+        int bit6;
         BYTE opcode, data;
 
         // very rough timing here;
@@ -1046,7 +1046,6 @@ BYTE zx81_opcode_fetch(int Address)
         // generate the TV picture (exactly how depends on which
         // display method is used)
 
-        if (!bit6) opcode=0;
         inv = data&128;
 
         bool zx80 = (emulator.machine == MACHINEZX80);
@@ -1068,7 +1067,6 @@ BYTE zx81_opcode_fetch(int Address)
                 FetchChromaColour(Address, data, lineCounter, memory);
 
                 data=zx81_ReadByte((z80.i<<8) | (z80.r7 & 128) | ((z80.r-1) & 127));
-                update=1;
         }
         else if ((z80.i&1) && (zx81.truehires==HIRESMEMOTECH) && MemotechMode)
         {
@@ -1083,15 +1081,14 @@ BYTE zx81_opcode_fetch(int Address)
                 if (!startOfDFile && (rRegister != 0x80 && rRegister != 0x81))
                 {
                         inv=(MemotechMode==3);
-                        update=1;
+                        bit6 = 0;
                 }
         }
         else if (zx81.truehires==HIRESQUICKSILVA && QuicksilvaHiResMode && syncOutputWhite)
         {
-                if (opcode!=118)
+                if (!bit6 && !z80.halted)
                 {
                         inv=0;
-                        update=1;
                         data=zx81_ReadByte(QsHiResAddress);
                         QsHiResAddress++;
                         if (QsHiResAddress == 0xB800)
@@ -1108,7 +1105,7 @@ BYTE zx81_opcode_fetch(int Address)
                 // register to generate an interrupt at the right time.
 
                 inv=0;
-                update=1;
+                bit6 = 0;
         }
         else if (!bit6)
         {
@@ -1162,14 +1159,12 @@ BYTE zx81_opcode_fetch(int Address)
                 {
                         data=255;
                 }
-
-                update=1;
         }
 
-        if (update)
+        if (!bit6 && !z80.halted)
         {
-                // Update gets set to true if we managed to fetch a bitmap from
-                // somewhere.  The only time this doesn't happen is if we encountered
+                // We managed to fetch a bitmap from somewhere.
+                // The only time this doesn't happen is if we encountered
                 // an opcode with bit 6 set above M1NOT.
 
                 if (machine.colour == COLOURLAMBDA)

--- a/Source/zx81/zx81.cpp
+++ b/Source/zx81/zx81.cpp
@@ -988,8 +988,8 @@ BYTE zx81_opcode_fetch(int Address)
 {
         static bool startOfDFile = true;
         static int calls = 0;
-        int inv;
-        int bit6;
+        bool inv;
+        bool bit6;
         BYTE opcode, data;
 
         // very rough timing here;


### PR DESCRIPTION
The emulation of frame timing for the Ace and Spectrum machines does not match real hardware. Cycles are dropped or added, and their timing related to frame interrupts is inconsistent.
These changes align frame interrupt timings correctly and do not drop/add cycles to frames. The Spectrum changes can be observed when running the attached utilities on any Speccy machine (specifically, minfo and ulatest3).
[zxtests-3p.zip](https://github.com/user-attachments/files/26468961/zxtests-3p.zip)
